### PR TITLE
Issue 40

### DIFF
--- a/microsetta_admin/server.py
+++ b/microsetta_admin/server.py
@@ -20,6 +20,8 @@ PUB_KEY = pkg_resources.read_text(
     'microsetta_admin',
     "authrocket.pubkey")
 
+DUMMY_SELECT_TEXT = '-------'
+
 
 def handle_pyjwt(pyjwt_error):
     # PyJWTError (Aka, anything wrong with token) will force user to log out
@@ -273,6 +275,15 @@ def scan():
             # Process result in python because its easier than jinja2.
             status_warnings, status_color = _check_sample_status(result)
 
+            # check the latest scan to find the default sample_status
+            # for form
+            latest_status = DUMMY_SELECT_TEXT
+            scans = result['scans_info']
+            if len(scans) > 0:
+                # get the latest scan--they are in ascending order by date
+                latest_scan = scans[len(scans)-1]
+                latest_status = latest_scan['sample_status']
+
             # sample_info may be None if barcode not in agp,
             # then no sample_site available
             return render_template(
@@ -281,6 +292,8 @@ def scan():
                 barcode_info=result["barcode_info"],
                 projects_info=result['projects_info'],
                 scans_info=result['scans_info'],
+                latest_status=latest_status,
+                dummy_status=DUMMY_SELECT_TEXT,
                 sample_info=result['sample'],
                 extended_info=result,
                 status_warnings=status_warnings,

--- a/microsetta_admin/server.py
+++ b/microsetta_admin/server.py
@@ -275,14 +275,10 @@ def scan():
             # Process result in python because its easier than jinja2.
             status_warnings, status_color = _check_sample_status(result)
 
-            # check the latest scan to find the default sample_status
-            # for form
+            # check the latest scan to find the default sample_status for form
             latest_status = DUMMY_SELECT_TEXT
-            scans = result['scans_info']
-            if len(scans) > 0:
-                # get the latest scan--they are in ascending order by date
-                latest_scan = scans[len(scans)-1]
-                latest_status = latest_scan['sample_status']
+            if result['latest_scan']:
+                latest_status = result['latest_scan']['sample_status']
 
             # sample_info may be None if barcode not in agp,
             # then no sample_site available

--- a/microsetta_admin/templates/scan.html
+++ b/microsetta_admin/templates/scan.html
@@ -6,7 +6,7 @@
         <table>
             <tr>
                 <td><label for="sample_barcode">Barcode: </label></td>
-                <td><input type="text" name="sample_barcode" id="sample_barcode" {% if barcode_info %} value="{{barcode_info.barcode}}"{% endif %}></td>
+                <td><input type="text" name="sample_barcode" id="sample_barcode"></td>
             </tr>
             <tr>
                 <td></td>

--- a/microsetta_admin/templates/scan.html
+++ b/microsetta_admin/templates/scan.html
@@ -18,9 +18,6 @@
             {{search_error |e}}
             </p>
         {% endif %}
-        <script>
-           document.search_form.sample_barcode.focus()
-        </script>
     </form>
 
     <br>
@@ -47,7 +44,7 @@
                 {% endif %}
             </div>
         </div>
-        <form action="/scan" name="update_form" id="update_form" method="post">
+        <form action="/scan" name="update_form" id="update_form" onsubmit="return verify_status();"   method="post">
         <input type="hidden" name="sample_barcode" value="{{barcode_info.barcode}}"/>
         <table>
             <tr>
@@ -113,13 +110,14 @@
                 <td>Sample Status: </td>
                 <td>
                 <select id="sample_status" name="sample_status">
-                {% for status in ["sample-is-valid",
+                {% for status in [dummy_status,
+                        "sample-is-valid",
                          "no-associated-source",
                          "no-registered-account",
                          "no-collection-info",
                          "sample-has-inconsistencies",
                          "received-unknown-validity"] %}
-                    <option value="{{status}}">{{status}}</option>
+                    <option value="{{status}}" {% if latest_status == status %}selected{% endif %} %}>{{status}}</option>
                 {% endfor %}
                 </select>
                 </td>
@@ -145,11 +143,20 @@
     {% endif %}
 
     <script>
-    {% if barcode_info %}
-       document.update_form.sample_status.focus();
-    {% else %}
-       document.search_form.sample_barcode.focus();
-    {% endif %}
+        // prevent submit with dummy status
+        function verify_status() {
+            let result = true;
+            let select_element = document.getElementById("sample_status");
+            let selected_status = select_element.options[select_element.selectedIndex].text;
+            if (selected_status === '{{ dummy_status }}'){
+                result = false;
+                alert("A scan cannot be saved without selecting a sample_status.");
+            }
+
+            return result;
+        }
+
+        document.search_form.sample_barcode.focus();
     </script>
 </div>
 {% endblock %}

--- a/microsetta_admin/tests/test_routes.py
+++ b/microsetta_admin/tests/test_routes.py
@@ -45,6 +45,7 @@ class RouteTests(TestBase):
         resp = {"barcode_info": {"barcode": "000004216"},
                 "projects_info": [],
                 "scans_info": [],
+                "latest_scan": None,
                 "sample": {'site': 'baz'},
                 "account": 'foo',
                 "source": 'bar'}
@@ -64,6 +65,7 @@ class RouteTests(TestBase):
         resp = {"barcode_info": {"barcode": "000004216"},
                 "projects_info": [],
                 "scans_info": [],
+                "latest_scan": None,
                 "sample": {'site': None},
                 "account": 'foo',
                 "source": 'bar'}
@@ -83,6 +85,7 @@ class RouteTests(TestBase):
         resp = {"barcode_info": {"barcode": "000004216"},
                 "projects_info": [],
                 "scans_info": [],
+                "latest_scan": None,
                 "sample": None,
                 "account": None,
                 "source": 'bar'}
@@ -102,6 +105,7 @@ class RouteTests(TestBase):
         resp = {"barcode_info": {"barcode": "000004216"},
                 "projects_info": [],
                 "scans_info": [],
+                "latest_scan": None,
                 "sample": None,
                 "account": None,
                 "source": None}


### PR DESCRIPTION
fix #40

Add code to select sample_status in dropdown based on status in latest scan, to add a "----" (no status selected) option to the dropdown for barcodes with no previous scans, to prevent adding a scan with "-----" as its sample_status, and to ensure that focus is always retained by the scan form (instead of the update_info) form unless the user specifically clicks into one of the elements of the latter.

NOTE: DEPENDS ON microsetta-private-api PR 245!