### PR TITLE
Issue 42

### DIFF
--- a/microsetta_admin/server.py
+++ b/microsetta_admin/server.py
@@ -244,9 +244,8 @@ def new_kits():
 def _check_sample_status(extended_barcode_info):
     warning = None
 
-    is_microsetta_by_project = [x["is_microsetta"] for x in
-                                extended_barcode_info["projects_info"]]
-    in_microsetta_project = True in is_microsetta_by_project
+    in_microsetta_project = any(
+        [x['is_microsetta'] for x in extended_barcode_info['projects_info']])
 
     # one warning to rule them all; check in order of precendence
     if not in_microsetta_project:

--- a/microsetta_admin/templates/scan.html
+++ b/microsetta_admin/templates/scan.html
@@ -25,25 +25,16 @@
     <br>
 
     {% if barcode_info %}
-        <div id="sample-status" class="sample-status" style="background-color:{{ status_color }};">
-           <div>
-                {% if status_warnings %}
-                <tr>
-                    <td>Status Warnings: </td>
-                </tr>
-                <tr>
-                    <td></td>
-                    <td>
-                        <ul>
-                        {% for warning in status_warnings %}
-                            <li>{{warning}}</li>
-                        {% endfor %}
-                        </ul>
-                    </td>
-                </tr>
-                {% endif %}
+        {% if status_warning %}
+            <div id="sample-status" class="sample-status" style="background-color:orange;">
+                <p>
+                    <br />
+                    Status Warning: {{status_warning}}
+                    <br/>
+                    <br/>
+                </p>
             </div>
-        </div>
+        {% endif %}
         <form action="/scan" name="update_form" id="update_form" onsubmit="return verify_status();"   method="post">
         <input type="hidden" name="sample_barcode" value="{{barcode_info.barcode}}"/>
         <table>
@@ -110,13 +101,7 @@
                 <td>Sample Status: </td>
                 <td>
                 <select id="sample_status" name="sample_status">
-                {% for status in [dummy_status,
-                        "sample-is-valid",
-                         "no-associated-source",
-                         "no-registered-account",
-                         "no-collection-info",
-                         "sample-has-inconsistencies",
-                         "received-unknown-validity"] %}
+                {% for status in status_options %}
                     <option value="{{status}}" {% if latest_status == status %}selected{% endif %} %}>{{status}}</option>
                 {% endfor %}
                 </select>

--- a/microsetta_admin/tests/test_routes.py
+++ b/microsetta_admin/tests/test_routes.py
@@ -154,7 +154,8 @@ class RouteTests(TestBase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'<td>000004216</td>', response.data)
-        self.assertIn(b'Status Warning: received-unknown-validity', response.data)
+        self.assertIn(b'Status Warning: received-unknown-validity',
+                      response.data)
 
     def test_create_kits_simple(self):
         self.mock_get.return_value.status_code = 200

--- a/microsetta_admin/tests/test_routes.py
+++ b/microsetta_admin/tests/test_routes.py
@@ -41,7 +41,7 @@ class RouteTests(TestBase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'<h3>Microsetta Scan</h3>', response.data)
 
-    def test_scan_specific_okay(self):
+    def test_scan_specific_no_warnings(self):
         resp = {"barcode_info": {"barcode": "000004216"},
                 "projects_info": [],
                 "scans_info": [],
@@ -61,12 +61,17 @@ class RouteTests(TestBase):
         self.assertIn(b'<td>000004216</td>', response.data)
         self.assertNotIn(b'Status Warnings:', response.data)
 
-    def test_scan_specific_uncollected(self):
+    def test_scan_specific_no_collection_info_warning(self):
         resp = {"barcode_info": {"barcode": "000004216"},
-                "projects_info": [],
+                "projects_info": [{
+                    "project": "American Gut Project",
+                    "is_microsetta": True,
+                    "bank_samples": False,
+                    "plating_start_date": None
+                }],
                 "scans_info": [],
                 "latest_scan": None,
-                "sample": {'site': None},
+                "sample": {'datetime_collected': None},
                 "account": 'foo',
                 "source": 'bar'}
 
@@ -79,9 +84,59 @@ class RouteTests(TestBase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'<td>000004216</td>', response.data)
-        self.assertIn(b'Sample site not specified', response.data)
+        self.assertIn(b'Status Warning: no-collection-info', response.data)
 
-    def test_scan_specific_no_account(self):
+    def test_scan_specific_no_associated_source_warning(self):
+        resp = {"barcode_info": {"barcode": "000004216"},
+                "projects_info": [{
+                    "project": "American Gut Project",
+                    "is_microsetta": True,
+                    "bank_samples": False,
+                    "plating_start_date": None
+                }],
+                "scans_info": [],
+                "latest_scan": None,
+                "sample": None,
+                "account": "foo",
+                "source": None}
+
+        self.mock_get.return_value.status_code = 200
+        self.mock_get.return_value.text = json.dumps(resp)
+        self.mock_get.return_value.json = lambda: resp  # noqa
+
+        response = self.app.get('/scan?sample_barcode=000004216',
+                                follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'<td>000004216</td>', response.data)
+        self.assertIn(b'Status Warning: no-associated-source', response.data)
+
+    def test_scan_specific_no_registered_account_warning(self):
+        resp = {"barcode_info": {"barcode": "000004216"},
+                "projects_info": [{
+                    "project": "American Gut Project",
+                    "is_microsetta": True,
+                    "bank_samples": False,
+                    "plating_start_date": None
+                }],
+                "scans_info": [],
+                "latest_scan": None,
+                "sample": None,
+                "account": None,
+                "source": 'bar'}
+
+        self.mock_get.return_value.status_code = 200
+        self.mock_get.return_value.text = json.dumps(resp)
+        self.mock_get.return_value.json = lambda: resp  # noqa
+
+        response = self.app.get('/scan?sample_barcode=000004216',
+                                follow_redirects=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'<td>000004216</td>', response.data)
+        self.assertIn(b'Status Warning: no-registered-account', response.data)
+
+    def test_scan_specific_received_unknown_validity_warning(self):
         resp = {"barcode_info": {"barcode": "000004216"},
                 "projects_info": [],
                 "scans_info": [],
@@ -99,27 +154,7 @@ class RouteTests(TestBase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'<td>000004216</td>', response.data)
-        self.assertIn(b'No associated account', response.data)
-
-    def test_scan_specific_no_source(self):
-        resp = {"barcode_info": {"barcode": "000004216"},
-                "projects_info": [],
-                "scans_info": [],
-                "latest_scan": None,
-                "sample": None,
-                "account": None,
-                "source": None}
-
-        self.mock_get.return_value.status_code = 200
-        self.mock_get.return_value.text = json.dumps(resp)
-        self.mock_get.return_value.json = lambda: resp  # noqa
-
-        response = self.app.get('/scan?sample_barcode=000004216',
-                                follow_redirects=True)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(b'<td>000004216</td>', response.data)
-        self.assertIn(b'No associated source', response.data)
+        self.assertIn(b'Status Warning: received-unknown-validity', response.data)
 
     def test_create_kits_simple(self):
         self.mock_get.return_value.status_code = 200


### PR DESCRIPTION
Fix issue #42 : if a barcode is found to have missing info of some sort, display only ONE warning message and use terminology matching the actual sample_status values shown in the status dropdown.   Depends upon https://github.com/biocore/microsetta-private-api/pull/253 to get slightly more nuanced info on account association to support use of 'no-associated-source' warning.