### PR TITLE
Unit tests for javascript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Node modules
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ lint:
 
 test: all
 	py.test
+	./run_js_tests.sh	
 
 test-cov: all
 	py.test --cov=microsetta_admin

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ test: all
 
 test-cov: all
 	py.test --cov=microsetta_admin
+	./run_js_tests.sh
 
 install: all
 	$(PYTHON) setup.py install

--- a/microsetta_admin/static/js/testable.js
+++ b/microsetta_admin/static/js/testable.js
@@ -1,0 +1,12 @@
+highFive = function(){ return 5; }
+ret7 = function(){return 12;}
+
+// Expose any unit testable functionality to node's module.exports
+// This will enable these functions to be called by our test suite.
+// If statement prevents dereferencing null when script is included in browser.
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined'){
+  module.exports = {
+    "highFive": highFive,
+    "ret7": ret7
+  }
+}

--- a/microsetta_admin/static/js/testable.js
+++ b/microsetta_admin/static/js/testable.js
@@ -1,5 +1,5 @@
 highFive = function(){ return 5; }
-ret7 = function(){return 12;}
+ret7 = function(){return 7;}
 
 // Expose any unit testable functionality to node's module.exports
 // This will enable these functions to be called by our test suite.

--- a/microsetta_admin/tests/js/README.txt
+++ b/microsetta_admin/tests/js/README.txt
@@ -1,0 +1,27 @@
+To run locally, you'll need to install node/npm, this will then be used to
+install qunit and all dependencies. You can then run make test, or if you just
+want the javascript tests, run_js_tests.sh at the root of the repo.
+
+Note that there is a compromise made to enable testing by command line: any
+testable functions must be retrievable through node. This means declaring them
+in the node defined module.exports field at the bottom of js files.
+Since the browser has no concept of module.exports, you must check for existence
+before setting this field. For a simple example of this, see
+
+  * microsetta_admin/static/js/testable.js.
+
+In the future, if you want to update qunit, you don't need to (and shouldn't)
+commit node_modules to the repo.
+
+Instead:
+
+cd <repo root>/microsetta_admin/tests/js/         (Goes to this folder)
+npm install qunit                                 (Builds the node_modules folder and updates contents of package-lock.json)
+git add package-lock.json                         (Adds package-lock.json)
+git commit                                        (Commits package-lock.json)
+
+Note that run_js_tests.sh will use npm ci to reproduce whatever is specified by
+the package-lock file.
+
+The package-lock.json defines the exact node package configuration that is used
+by travis, so the build will automatically update to use your new configuration.

--- a/microsetta_admin/tests/js/package-lock.json
+++ b/microsetta_admin/tests/js/package-lock.json
@@ -1,0 +1,83 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "commander": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "js-reporters": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.1.tgz",
+      "integrity": "sha1-+IxgjjJKM3OpW8xFrTBeXJecRZs=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "node-watch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.6.1.tgz",
+      "integrity": "sha512-gwQiR7weFRV8mAtT0x0kXkZ18dfRLB45xH7q0hCOVQMLfLb2f1ZaSvR57q4/b/Vj6B0RwMNJYbvb69e1yM7qEA==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "qunit": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.10.1.tgz",
+      "integrity": "sha512-6ntXpabAW+ycodADqsC2QWPr6xLubag3WBujaAfOlltgwkBVDmM0gkB5dS2Mc4RAszmvtYzyYDSMZX5ibwkNWw==",
+      "dev": true,
+      "requires": {
+        "commander": "2.12.2",
+        "js-reporters": "1.2.1",
+        "minimatch": "3.0.4",
+        "node-watch": "0.6.1",
+        "resolve": "1.9.0"
+      }
+    },
+    "resolve": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+      "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    }
+  }
+}

--- a/microsetta_admin/tests/js/package.json
+++ b/microsetta_admin/tests/js/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "test": "qunit"
+  },
+  "devDependencies": {
+    "qunit": "^2.10.1"
+  }
+}

--- a/microsetta_admin/tests/js/test/example_test.js
+++ b/microsetta_admin/tests/js/test/example_test.js
@@ -1,0 +1,8 @@
+const testable = require("../../../static/js/testable")
+
+QUnit.module('testable', function() {
+  QUnit.test('Test testable functions', function(assert){
+    assert.equal(testable.highFive(), 5, "Get high 5")
+    assert.equal(testable.ret7(), 7, "Returns 7")
+    })
+})

--- a/run_js_tests.sh
+++ b/run_js_tests.sh
@@ -1,0 +1,3 @@
+cd microsetta_admin/tests/js
+npm ci
+npm run test


### PR DESCRIPTION
Requires qunit from npm/node in order to run tests from command line.  Installs a node_modules folder containing qunit based on the package-lock.json in the microsetta_admin/tests/js folder.  

First build should fail with the new unit tests - hopefully