### PR TITLE
Issues 46 47

### DIFF
--- a/microsetta_admin/server.py
+++ b/microsetta_admin/server.py
@@ -318,6 +318,7 @@ def _scan_get(sample_barcode, update_error):
             status_warning=status_warning,
             update_error=update_error,
             received_type_dropdown=RECEIVED_TYPE_DROPDOWN,
+            source=result['source'],
             events=events
         )
     elif status == 401:

--- a/microsetta_admin/templates/scan.html
+++ b/microsetta_admin/templates/scan.html
@@ -214,6 +214,20 @@ table
                     </ul>
                 </td>
             </tr>
+            {% if source is not none %}
+            <tr>
+                <td>Source Type: </td>
+                <td>{{source.source_type}}</td>
+            </tr>
+            <tr>
+                <td>Source Name: </td>
+                <td>{{source.name}}</td>
+            </tr>
+            <tr>
+                <td>Source Description: </td>
+                <td>{{source.source_data.description}}</td>
+            </tr>
+            {% endif %}
             <tr>
                 <td>Sample Site: </td>
                 <td>{{sample_info.site}}</td>

--- a/microsetta_admin/templates/search_result.html
+++ b/microsetta_admin/templates/search_result.html
@@ -132,7 +132,15 @@
                     <tbody>
                     {% for sample in result['kit']['samples'] %}
                         <tr>
-                            <td><a href="{{ ui_endpoint }}/accounts/{{ result['account']['id'] }}/sources/{{ result['source']['id'] }}/samples/{{ sample['id'] }}" target="_blank">Edit sample</a></td>
+                            <td>
+                            {% if sample['account_id'] is none %}
+                            No account
+                            {% elif sample['source_id'] is none %}
+                            No source
+                            {% else %}
+                            <a href="{{ ui_endpoint }}/accounts/{{ sample['account_id'] }}/sources/{{ sample['source_id'] }}/samples/{{ sample['id'] }}" target="_blank">Edit sample</a>
+                            {% endif %}
+                            </td>
                             <td>{{ sample['barcode'] }}</td>
                             <td>{{ sample['site'] }}</td>
                             <td>{{ sample['datetime_collected'] }}</td>

--- a/microsetta_admin/tests/test_routes.py
+++ b/microsetta_admin/tests/test_routes.py
@@ -52,8 +52,10 @@ class RouteTests(TestBase):
             "scans_info": [],
             "latest_scan": None,
             "sample": {'site': 'baz'},
-            "account": {'id': 'd8592c74-9694-2135-e040-8a80115d6401'},
-            "source": 'bar'
+            "source": {'name': 'a source a name',
+                       'source_type': 'human',
+                       'source_data': {'description': None}},
+            "account": {'id': 'd8592c74-9694-2135-e040-8a80115d6401'}
         }
 
         resp2 = []
@@ -90,7 +92,9 @@ class RouteTests(TestBase):
             "latest_scan": None,
             "sample": {'datetime_collected': None},
             "account": {'id': "ThizIzNotReal"},
-            "source": 'bar'
+            "source": {'name': 'a source a name',
+                       'source_type': 'human',
+                       'source_data': {'description': None}},
         }
 
         resp2 = []
@@ -161,7 +165,7 @@ class RouteTests(TestBase):
                 "latest_scan": None,
                 "sample": None,
                 "account": None,
-                "source": 'bar'}
+                "source": None}
 
         self.mock_get.return_value.status_code = 200
         self.mock_get.return_value.text = json.dumps(resp)
@@ -181,7 +185,7 @@ class RouteTests(TestBase):
                 "latest_scan": None,
                 "sample": None,
                 "account": None,
-                "source": 'bar'}
+                "source": None}
 
         self.mock_get.return_value.status_code = 200
         self.mock_get.return_value.text = json.dumps(resp)


### PR DESCRIPTION
Fixes #46
Fixes #47 

Sample editing from search now correctly gets source and account IDs. #46 is dependent on biocore/microsetta-private-api#259

Support showing the source type, name and description to facilitate scanning environmental samples

