### PR TITLE
Alter manage projects page to allow filtering by project active status

### DIFF
--- a/microsetta_admin/server.py
+++ b/microsetta_admin/server.py
@@ -169,9 +169,9 @@ def _translate_nones(a_dict, do_none_to_str):
 @app.route('/manage_projects', methods=['GET', 'POST'])
 def manage_projects():
     result = None
+    is_active = request.args.get('is_active', None)
+    projects_uri = '/api/admin/projects'
     if request.method == 'POST':
-        projects_uri = '/api/admin/projects'
-
         model = {x: request.form[x] for x in request.form}
         project_id = model.pop('project_id')
         model['is_microsetta'] = model.get('is_microsetta', '') == 'true'
@@ -198,7 +198,10 @@ def manage_projects():
     # if the above work (if any) didn't produce an error message, return
     # the projects list
     if result is None:
-        status, projects_output = APIRequest.get('/api/admin/projects')
+        get_url = projects_uri
+        if is_active is not None:
+            get_url += f"?is_active={is_active}"
+        status, projects_output = APIRequest.get(get_url)
 
         if status >= 400:
             result = {'error_message': "Unable to load project list."}

--- a/microsetta_admin/templates/manage_projects.html
+++ b/microsetta_admin/templates/manage_projects.html
@@ -102,7 +102,25 @@
         $('#wait_msg').show();
     }
 
+    function loadByActiveStatus(statusSelect){
+        let manage_projects_url = "/manage_projects";
+        let active_status_filter = statusSelect.value;
+        if (active_status_filter !== "all"){
+            manage_projects_url+= "?is_active="+ active_status_filter;
+        }
+        showWait(manage_projects_url);
+    }
+
     $(document).ready(function() {
+        // set active status drop-down value; note that this code-level change
+        // does NOT trigger the drop-down's onchange event (which reloads the page)
+        let urlParams = new URLSearchParams(window.location.search);
+        let is_active_val = "all";
+        if (urlParams.has('is_active')){
+            is_active_val = urlParams.get('is_active');
+        }
+        $('#is_active_val').val(is_active_val);
+
         document.getElementById('bank_samples').onchange = function() {
             // the 'plating_start_date input field is disabled if
             // the 'bank_samples' checkbox is NOT checked, and enabled if it is.
@@ -189,6 +207,14 @@
     <div>
         <div class="result_container">
             <div class="dataTables_wrapper">
+                <div>
+                    <select id="is_active_val" onchange="loadByActiveStatus(this);">
+                        <option value="true">Active</option>
+                        <option value="false">Inactive</option>
+                        <option value="all">All</option>
+                    </select>
+                </div>
+                <br />
                 <table id="projects_list" class="display wrap" style="width:100%">
                     <thead>
                         <tr>

--- a/microsetta_admin/templates/sitebase.html
+++ b/microsetta_admin/templates/sitebase.html
@@ -37,7 +37,7 @@
         <ul class="mainmenu">
             {% if email %}
             <li><a href="/search">Search</a></li>
-            <li><a href="#" onclick="showWait('/manage_projects')">Manage Projects</a></li>
+            <li><a href="#" onclick="showWait('/manage_projects?is_active=true')">Manage Projects</a></li>
             <li><a href="/create_kits">Create Kit</a></li>
             <li><a href="/scan">Scan Barcode</a></li>
             <li><a href="/metadata_pulldown">Retrieve Metadata</a></li>


### PR DESCRIPTION
Adds an optional querystring parameter to the manage projects page that designates whether to display only active or only inactive projects.  This param is true by default (only show active projects) but can be altered by the user by changing value in a new drop-down to active, inactive, or all.  The current filter (whatever it is) is retained when the user reloads the page or creates/updates a project (which also causes a page reload).

Note that right now the user CANNOT change the active status of any particular project in this interface, and all newly created projects are active by default.

NB: Depends on microsetta-private-api PR #266 (Designate active projects) for back-end functionality.