### PR TITLE
Remove background image and add conditional links to branding instructions

### DIFF
--- a/microsetta_admin/static/css/ma_interface.css
+++ b/microsetta_admin/static/css/ma_interface.css
@@ -1,10 +1,6 @@
 body, html {
     width:100%; 
-    height:100%; 
-    background-image: 
-        url(/static/img/background3.jpg); 
-    background-repeat:no-repeat; 
-    background-size:cover;
+    height:100%;
 }
 
 .menu {

--- a/microsetta_admin/templates/manage_projects.html
+++ b/microsetta_admin/templates/manage_projects.html
@@ -141,7 +141,21 @@
         // end from https://getbootstrap.com/docs/4.0/components/modal/
 
         projectTable = $('#projects_list').DataTable({
+            // Set the "Branding Associated Instructions" column to display
+            // its content as a link if they contain :// (as in http://, https://, etc)
+            "columnDefs": [{
+                "targets": 35,
+                "render": function (data, type, row, meta) {
+                    let result = data;
+                    if (data.indexOf("://") > -1) {
+                        result = '<a href="' + data + '">' + data + '</a>';
+                    }
+                    return result;
+                }
+            }],
+            // Enable horizontal scrolling of DataTable
             "scrollX": true,
+            // Define groups of columns that will be showed/hidden by named buttons
             // modified from https://datatables.net/extensions/buttons/examples/column_visibility/columnGroups.html#:~:text=SearchPanes-,Column%20groups,provides%20this%20ability%20for%20Buttons
             dom: 'Bfrtip',
             buttons: [


### PR DESCRIPTION
SOME (but not all ... ) of the branding instructions table entries are links.  Added code to the DataTables definition to show them as links if they look "url-ish".  It is rather ugly (bc shows whole link in display) and could generate a link not actually accessible from a browser under edge cases like someone entering eg ftp://<mystuff>.  However, I class this as "better than nothing".  
<img width="961" alt="Screen Shot 2020-09-30 at 2 39 26 PM" src="https://user-images.githubusercontent.com/10677935/94742819-2d18a900-032b-11eb-82d4-8823735b01be.png">
