### PR TITLE
Updated project info handling

### DIFF
--- a/microsetta_admin/templates/create_kits.html
+++ b/microsetta_admin/templates/create_kits.html
@@ -1,4 +1,31 @@
 {% extends "sitebase.html" %}
+{% block head %}
+
+<script src="/static/vendor/js/jquery.validate.min.js"></script>
+<script>
+    $(document).ready(function(){
+        // Initialize form validation on the registration form.
+        // It has the name attribute "registration"
+        $("form[name='kit_form']").validate({
+            // Specify validation rules
+            rules: {
+                // The key name on the left side is the name attribute
+                // of an input field. Validation rules are defined
+                // on the right side
+                num_kits: "required",
+                num_samples: "required",
+                project_ids: "required",
+                // Make sure the form is submitted to the destination defined
+                // in the "action" attribute of the form when valid
+                submitHandler: function (form) {
+                    form.submit();
+                }
+            }
+        });
+    });
+</script>
+
+{% endblock %}
 {% block content %}
 <h3>Microsetta Create Kits</h3>
 <style>
@@ -8,12 +35,12 @@
     }
 </style>
 <div style="height: 400px;">
-    {% if error %}
+    {% if error_message %}
         <p style="color:red">
-        {{error |e}}
+            {{ error_message |e }}
         </p>
     {% endif %}
-        
+
     <form name="kit_form" id="kit_form" method="POST">
         <table>
             <tr>
@@ -29,11 +56,15 @@
                 <td><input type="text" name="prefix" id="prefix" ></td>
             </tr>
             <tr>
-                <td><label for="project">Projects: </label></td>
-                <td><select id="create-select-project" name="projects" multiple class="chosen-select" size=10>
+                <td><label for="project_ids">Projects: </label></td>
+                <td><select id="project_ids" name="project_ids" multiple class="chosen-select" size=10>
+                    {% if projects %}
                     {% for p in projects %}
-                    <option value='{{p}}'>{{p}}</option>
+
+                    <option value='{{p['project_id']}}'>{{p['project_name']}}</option>
+
                     {% endfor %}
+                    {% endif %}
                 </select></td>
             </tr>
             <tr>

--- a/microsetta_admin/templates/sitebase.html
+++ b/microsetta_admin/templates/sitebase.html
@@ -6,6 +6,8 @@
 <link rel="stylesheet" href="/static/vendor/bootstrap-4.4.1-dist/css/bootstrap.min.css" />
 <link rel="stylesheet" href="/static/css/ma_interface.css" />
 <style>
+    /* ignore IDE lies--this style IS used: it modifies a class
+    imported from the bootstrap libraries for use with modal windows */
     .modal-backdrop {
         /* bug fix - no overlay */
         display: none;

--- a/microsetta_admin/tests/test_routes.py
+++ b/microsetta_admin/tests/test_routes.py
@@ -275,7 +275,6 @@ class RouteTests(TestBase):
                       response.data)
 
     def test_create_kits_get_fail(self):
-        proj_list = deepcopy(self.PROJ_LIST)
         self.mock_get.return_value = DummyResponse(400, "")
 
         response = self.app.get('/create_kits', follow_redirects=True)

--- a/microsetta_admin/tests/test_routes.py
+++ b/microsetta_admin/tests/test_routes.py
@@ -265,13 +265,22 @@ class RouteTests(TestBase):
         self.assertIn(b'Status Warning: received-unknown-validity',
                       response.data)
 
-    def test_create_kits_simple(self):
-        self.mock_get.return_value = DummyResponse(200,
-                                                   [{"project_name": "foo"}])
+    def test_create_kits_get_success(self):
+        proj_list = deepcopy(self.PROJ_LIST)
+        self.mock_get.return_value = DummyResponse(200, proj_list)
 
         response = self.app.get('/create_kits', follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'<h3>Microsetta Create Kits</h3>', response.data)
+        self.assertIn(b'<option value=\'12\'>New proj</option>',
+                      response.data)
+
+    def test_create_kits_get_fail(self):
+        proj_list = deepcopy(self.PROJ_LIST)
+        self.mock_get.return_value = DummyResponse(400, "")
+
+        response = self.app.get('/create_kits', follow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Unable to load project list', response.data)
 
     def test_create_project_success(self):
         api_post_dummy = DummyResponse(201, {})


### PR DESCRIPTION
This PR *requires* the private-api PR #269 (Adds ability to get project info without stats (for speed)) and private-api PR #268 (Passes around lists of project ids rather than project names).  Do not merge into this repo until those are merged into private-api :)

This updates the admin front end to use the new include_stats=False switch to pull the project list for the create_kits page so it gets a minimal info list (faster).  It also changes create_kits to pass around project ids (rather than project names) which is what the private-api is now expecting (users still see the project names, of course :) .  Also threw in a bit of validation on that page to reduce the amount of server-level checking needed.  Project querying from the private-api is centralized to a private function on server so it can be called in all the admin page endpoints that need it (create_kits, manage_projects, and--in the near future--submit daklapack orders).

