### PR TITLE
Enhance pl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# microsetta-admin
+# microsetta-adminname: microsetta-admin CI
+
+conda create --name test-microsetta-admin python=3.7
+conda activate test-microsetta-admin
+conda install --yes --file ci/conda_requirements.txt
+pip install -r ci/pip_requirements.txt
+make install
+conda activate test-microsetta-admin
+
+before make test, add:
+conda install -c conda-forge nodejs
+
+make test

--- a/microsetta_admin/server.py
+++ b/microsetta_admin/server.py
@@ -176,7 +176,8 @@ def _get_projects(include_stats, is_active):
     status, projects_output = APIRequest.get(projects_uri)
 
     if status >= 400:
-        result = {'error_message': f"Unable to load project list: {projects_uri}"}
+        result = {'error_message': f"Unable to load project list: "
+                                   f"{projects_uri}"}
     else:
         cleaned_projects = [_translate_nones(x, True) for x in
                             projects_output]
@@ -337,7 +338,8 @@ def per_sample_summary():
 
     # build a list of dictionaries with just the project id and the project
     # name.
-    projects = [{'project_name': x['project_name'], 'project_id': x['project_id']} for x in projects]
+    projects = [{'project_name': x['project_name'],
+                 'project_id': x['project_id']} for x in projects]
 
     # determine if user wants sample ids stripped
     strip_sampleid = request.form.get('strip_sampleid', 'off')
@@ -362,20 +364,37 @@ def per_sample_summary():
         if project_id is not None:
             # user wants to get summaries on all samples in a project.
             payload = {'project_id': project_id}
-            status, result = APIRequest.post('/api/admin/account_barcode_summary?strip_sampleid=False', json=payload)
+            status, result = APIRequest.post('/api/admin/account_barcode_summa'
+                                             'ry?strip_sampleid=False',
+                                             json=payload)
 
             if status == 200:
-                resource = pd.DataFrame(result)
-                order = ['sampleid', 'project', 'account-email','source-email',
-                         'source-type', 'site-sampled', 'sample-status',
-                         'sample-received', 'ffq-taken', 'ffq-complete',
-                         'vioscreen_username']
+                if result['partial_result'] is True:
+                    unprocessed_barcodes = result['unprocessed_barcodes']
+                else:
+                    unprocessed_barcodes = None
+
+                resource = pd.DataFrame(result['samples'])
+                order = ['sampleid', 'project', 'account-email',
+                         'source-email', 'source-type', 'site-sampled',
+                         'sample-status', 'sample-received', 'ffq-taken',
+                         'ffq-complete', 'vioscreen_username']
                 order.extend(sorted(set(resource.columns) - set(order)))
                 resource = resource[order]
-                return render_template('per_sample_summary.html',
-                                       resource=resource,
-                                       projects=projects,
-                                       **build_login_variables())
+                if unprocessed_barcodes:
+                    return render_template('per_sample_summary.html',
+                                           resource=resource,
+                                           projects=projects,
+                                           error_message="Too many barcodes. S"
+                                                         "erver processed only"
+                                                         " the first 1000.",
+                                           **build_login_variables())
+                else:
+                    return render_template('per_sample_summary.html',
+                                           resource=resource,
+                                           projects=projects,
+                                           **build_login_variables())
+
             else:
                 return render_template('per_sample_summary.html',
                                        resource=None,
@@ -390,31 +409,49 @@ def per_sample_summary():
         # assume POST, since there are only two methods defined in route.
         # if we are here, it is because the user is querying using an uploaded
         # file containing sample names.
-        sample_barcodes, upload_err = upload_util.parse_request_csv_col(request, 'file', 'sample_name')
-        if upload_err is not None:
+        sample_barcodes, err = upload_util.parse_request_csv_col(request,
+                                                                 'file',
+                                                                 'sample_name')
+        if err is not None:
             # there was an error. abort early.
             return render_template('per_sample_summary.html',
                                    resource=None,
                                    projects=projects,
                                    **build_login_variables(),
-                                   search_error=[{'error': upload_err}])
+                                   search_error=[{'error': err}])
 
     # perform the main query.
     payload = {'sample_barcodes': sample_barcodes}
-    status, result = APIRequest.post('/api/admin/account_barcode_summary?strip_sampleid=%s' % str(strip_sampleid), json=payload)
+    status, result = APIRequest.post('/api/admin/account_barcode_summary?stri'
+                                     'p_sampleid=%s' % str(strip_sampleid),
+                                     json=payload)
 
     if status == 200:
-        resource = pd.DataFrame(result)
+        if result['partial_result'] is True:
+            unprocessed_barcodes = result['unprocessed_barcodes']
+        else:
+            unprocessed_barcodes = None
+        resource = pd.DataFrame(result['samples'])
         order = ['sampleid', 'project', 'account-email', 'source-email',
                  'source-type', 'site-sampled', 'sample-status',
                  'sample-received', 'ffq-taken', 'ffq-complete',
                  'vioscreen_username']
         order.extend(sorted(set(resource.columns) - set(order)))
         resource = resource[order]
-        return render_template('per_sample_summary.html',
-                               resource=resource,
-                               projects=projects,
-                               **build_login_variables())
+
+        if unprocessed_barcodes:
+            return render_template('per_sample_summary.html',
+                                   resource=resource,
+                                   projects=projects,
+                                   error_message="Too many barcodes. S"
+                                                 "erver processed only"
+                                                 " the first 1000.",
+                                   **build_login_variables())
+        else:
+            return render_template('per_sample_summary.html',
+                                   resource=resource,
+                                   projects=projects,
+                                   **build_login_variables())
     else:
         return render_template('per_sample_summary.html',
                                resource=None,
@@ -429,17 +466,32 @@ def _get_by_sample_barcode(sample_barcodes, strip_sampleid, projects):
                                      'strip_sampleid=%s' % str(strip_sampleid),
                                      json=payload)
     if status == 200:
-        resource = pd.DataFrame(result)
+        if result['partial_result'] is True:
+            unprocessed_barcodes = result['unprocessed_barcodes']
+        else:
+            unprocessed_barcodes = None
+
+        resource = pd.DataFrame(result['samples'])
         order = ['sampleid', 'project', 'account-email', 'source-email',
                  'source-type', 'site-sampled', 'sample-status',
                  'sample-received', 'ffq-taken', 'ffq-complete',
                  'vioscreen_username']
         order.extend(sorted(set(resource.columns) - set(order)))
         resource = resource[order]
-        return render_template('per_sample_summary.html',
-                               resource=resource,
-                               projects=projects,
-                               **build_login_variables())
+
+        if unprocessed_barcodes:
+            return render_template('per_sample_summary.html',
+                                   resource=resource,
+                                   projects=projects,
+                                   error_message="Too many barcodes. S"
+                                                 "erver processed only"
+                                                 " the first 1000.",
+                                   **build_login_variables())
+        else:
+            return render_template('per_sample_summary.html',
+                                   resource=resource,
+                                   projects=projects,
+                                   **build_login_variables())
     else:
         return render_template('per_sample_summary.html',
                                resource=None,

--- a/microsetta_admin/server.py
+++ b/microsetta_admin/server.py
@@ -176,7 +176,7 @@ def _get_projects(include_stats, is_active):
     status, projects_output = APIRequest.get(projects_uri)
 
     if status >= 400:
-        result = {'error_message': "Unable to load project list."}
+        result = {'error_message': f"Unable to load project list: {projects_uri}"}
     else:
         cleaned_projects = [_translate_nones(x, True) for x in
                             projects_output]
@@ -325,9 +325,13 @@ def email_stats():
                            **build_login_variables(),
                            projects=projects)
 
-
 @app.route('/per_sample_summary', methods=['GET', 'POST'])
 def per_sample_summary():
+    _, result = _get_projects(include_stats=False, is_active=True)
+    projects = result.get('projects')
+    projects = [x['project_name'] for x in projects if x['is_microsetta'] is True]
+    print("PROJECTS: %s" % projects)
+
     strip_sampleid = request.form.get('strip_sampleid', 'off')
     strip_sampleid = strip_sampleid.lower() == 'on'
 
@@ -336,6 +340,7 @@ def per_sample_summary():
         if sample_barcode is None:
             return render_template('per_sample_summary.html',
                                    resource=None,
+                                   projects=projects,
                                    **build_login_variables())
         sample_barcodes = [sample_barcode, ]
     elif request.method == 'POST':
@@ -347,6 +352,7 @@ def per_sample_summary():
         if upload_err is not None:
             return render_template('per_sample_summary.html',
                                    resource=None,
+                                   projects=projects,
                                    **build_login_variables(),
                                    search_error=[{'error': upload_err}])
 
@@ -357,6 +363,7 @@ def per_sample_summary():
     if status != 200:
         return render_template('per_sample_summary.html',
                                resource=None,
+                               projects=projects,
                                error_message=result,
                                **build_login_variables())
     else:
@@ -369,6 +376,7 @@ def per_sample_summary():
         resource = resource[order]
         return render_template('per_sample_summary.html',
                                resource=resource,
+                               projects=projects,
                                **build_login_variables())
 
 

--- a/microsetta_admin/templates/per_sample_summary.html
+++ b/microsetta_admin/templates/per_sample_summary.html
@@ -62,14 +62,29 @@
     </form>
     <hr class="dashed">
     <h5>Retrieve status for all samples in a project</h5>
-    <form name="cc_form" id="cc_form" method="POST">
+    <form name="cc_form" id="cc_form" method="GET">
+    <table width=100% border=0>
+        <tr>
+            <td colspan=3>
+            <select id="project_id" name="project_id">
+                 {% if projects %}
+                    {% for p in projects %}
+                        <option value='{{p['project_id']}}'>{{p['project_name']}}</option>
+                    {% endfor %}
+                 {% endif %}
+            </select>
+            </td>
+            <td colspan=1 style="text-align:right;padding:4px"><input type="submit" value="Retrieve"></td>
+        </tr>
+    </table>
+    <!--
     <table width=100% border=0>
         <tr>
             <td colspan=3>
             <select id="project_ids" name="project_ids" class="chosen-select" size=5>
                 {% if projects %}
                     {% for p in projects %}
-                        <option value='{{p}}'>{{p}}</option>
+                        <option value='{{p['project_id']}}'>{{p['project_name']}}</option>
                     {% endfor %}
                 {% endif %}
             </select>
@@ -77,6 +92,9 @@
             <td colspan=1 style="text-align:right;padding:4px"><input type="submit" value="Retrieve"></td>
         </tr>
     </table>
+    <script> document.cc_form.project_ids.focus() </script>
+    -->
+    </form>
 </div>
 {% if resource is not none %}
 <div class="result_container">

--- a/microsetta_admin/templates/per_sample_summary.html
+++ b/microsetta_admin/templates/per_sample_summary.html
@@ -25,39 +25,62 @@
 </script>
 {% endblock %}
 {% block content %}
-<h3>Microsetta Per Sample Summary</h3>
-<div style="height: 400px;">
+<h3>Sample Summaries</h3>
+<hr class="dashed">
+<h5>Retrieve summary for a single sample</h5>
+<div style="height: 400px; width: 400px">
     {% if error_message %}
         <p style="color:red">
             {{ error_message |e }}
         </p>
     {% endif %}
     <form name="search_form" id="search_form" method="GET">
-        <table>
+        <table width=100% border=0>
+        <tr>
+            <td colspan=3 style="text-align:left;padding:4px"> <input type="text" name="sample_barcode" placeholder="Enter barcode here" id="sample_barcode" {% if info %} value="{{info.barcode}}"{% endif %}> </td>
+            <td colspan=1 style="text-align:right;padding:4px"> <input type="submit" value="Retrieve"> </td>
+        </tr>
+        </table>
+        <script> document.search_form.sample_barcode.focus() </script>
+    </form>
+    <hr class="dashed">
+    <h5>Retrieve summaries using a csv file</h5>
+    <form name="upload_csv" id="search_csv" method="POST" enctype="multipart/form-data" onsubmit="return remove_error_messages()">
+        <table width=100% border=0>
             <tr>
-                <td><label for="sample_barcode">Barcode: </label></td>
-                <td><input type="text" name="sample_barcode" id="sample_barcode" {% if info %} value="{{info.barcode}}"{% endif %}></td>
-                <td></td>
-                <td><input type="submit" value="Retrieve Summary"></td>
+                <td colspan=3 style="text-align:left;padding:4px"><input type=file name=file></td>
+                <td colspan=1 style="text-align:right;padding:4px"><input type=submit value=Upload></td>
+            </tr>
+            <tr><td colspan=4></td></tr>
+            <tr><td colspan=4 style="text-align:center;padding:4px"><i>Barcodes must be listed in column "sample_name"<br>(max: 1000)</i> </td></tr>
+            <tr><td colspan=4></td></tr>
+            <tr>
+                <td colspan=3> <label for="strip_sampleid"> Check to remove sample IDs from summary</label> </td>
+                <td colspan=1 style="text-align:center;padding:4px"> <input type="checkbox" id="strip_sampleid" name="strip_sampleid"> </td>
             </tr>
         </table>
-        <script>
-           document.search_form.sample_barcode.focus()
-        </script>
     </form>
-    <br/>
-    Or upload a file of barcodes listed in the column "sample_name" (max: 1000)
-    <br/>
-    <form name="upload_csv" id="search_csv" method="POST" enctype="multipart/form-data" onsubmit="return remove_error_messages()">
-      <input type="checkbox" id="strip_sampleid" name="strip_sampleid">
-      <label for="strip_sampleid"> Check to remove sample IDs from summary</label><br/>
-      <input type=file name=file><br/>
-      <input type=submit value=Upload>
-    </form>
-    {% if resource is not none %}
-    <div class="result_container">
-    {{resource.to_html(table_id="search_results", classes=["display"], render_links=True, escape=False) |safe}}
-    </div>
+    <hr class="dashed">
+    <h5>Retrieve status for all samples in a project</h5>
+    <form name="cc_form" id="cc_form" method="POST">
+    <table width=100% border=0>
+        <tr>
+            <td colspan=3>
+            <select id="project_ids" name="project_ids" class="chosen-select" size=5>
+                {% if projects %}
+                    {% for p in projects %}
+                        <option value='{{p}}'>{{p}}</option>
+                    {% endfor %}
+                {% endif %}
+            </select>
+            </td>
+            <td colspan=1 style="text-align:right;padding:4px"><input type="submit" value="Retrieve"></td>
+        </tr>
+    </table>
+</div>
+{% if resource is not none %}
+<div class="result_container">
+{{resource.to_html(table_id="search_results", classes=["display"], render_links=True, escape=False) |safe}}
 </div>
 {% endif %}
 {{blob}}

--- a/microsetta_admin/templates/sitebase.html
+++ b/microsetta_admin/templates/sitebase.html
@@ -49,7 +49,7 @@
             <li><a href="/create_kits">Create Kit</a></li>
             <li><a href="/scan">Scan Barcode</a></li>
             <li><a href="/metadata_pulldown">Retrieve Metadata</a></li>
-            <li><a href="/per_sample_summary">Per sample summary</a></li>
+            <li><a href="/per_sample_summary">Sample Summaries</a></li>
             <li><a href="/submit_daklapack_order">Submit Daklapack Order</a></li>
             <li><a href="{{authrocket_url}}/logout?redirect_uri={{endpoint}}/logout">Log Out <br> ({{email |e}})</a></li>
             {% else %}

--- a/microsetta_admin/tests/test_routes.py
+++ b/microsetta_admin/tests/test_routes.py
@@ -363,7 +363,7 @@ class RouteTests(TestBase):
         # the api call failed, but the admin page call succeeds--in returning
         # a page reporting the error :)
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'Unable to load project list.', response.data)
+        self.assertIn(b'Unable to load project list', response.data)
 
     def test_get_submit_daklapack_order_success(self):
         # server side issues two GETs to the API
@@ -477,7 +477,7 @@ class RouteTests(TestBase):
         response = self.app.get('/submit_daklapack_order',
                                 follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'Unable to load project list.', response.data)
+        self.assertIn(b'Unable to load project list', response.data)
 
     def _test_post_submit_daklapack_order(self, addresses_filename=None):
         if addresses_filename is None:


### PR DESCRIPTION
@wasade Requesting summaries for a project is now available on the per-sample summaries page. (Now renamed sample summaries).
This is still a work in progress. It needs flake8 and unittests. I want to also let the user get both a warning when over 1000 barcodes were requested, but also get the first 1000 samples. That will require a little tweaking. Should be ready before Monday.