### PR TITLE
Adjusting deprecated parameters for send_file()

### DIFF
--- a/microsetta_admin/server.py
+++ b/microsetta_admin/server.py
@@ -552,7 +552,7 @@ def new_kits():
         fname = f'kits-{stamp}.csv'
 
         return send_file(payload, as_attachment=True,
-                         attachment_filename=fname,
+                         download_name=fname,
                          mimetype='text/csv')
 
 
@@ -822,9 +822,9 @@ def metadata_pulldown():
         return send_file(bytestream,
                          mimetype="text/tab-separated-values",
                          as_attachment=True,
-                         attachment_filename="metadata_pulldown.tsv",
-                         add_etags=False,
-                         cache_timeout=None,
+                         download_name="metadata_pulldown.tsv",
+                         etag=False,
+                         max_age=None,
                          conditional=False,
                          last_modified=None,
                          )


### PR DESCRIPTION
Flask deprecated certain parameters of send_file in a recent release. Since the changes are relatively innocuous, it seems expedient to change them, rather than pinning the version we use for microsetta-admin.

Source - https://github.com/pallets/flask/issues/4753