### PR TITLE
Add Barcodes to Existing Kits

### DIFF
--- a/microsetta_admin/server.py
+++ b/microsetta_admin/server.py
@@ -516,6 +516,9 @@ def new_kits():
     elif request.method == 'POST':
         prefix = request.form['prefix']
         selected_project_ids = request.form.getlist('project_ids')
+        num_kits = request.form['num_kits']
+        num_samples = request.form['num_samples']
+        generate_barcodes = request.form.get('generate_barcodes_1')
 
         barcodes = []
 
@@ -529,7 +532,10 @@ def new_kits():
 
         payload = {
             'action': 'create' if not barcodes else 'insert',
-            'project_ids': selected_project_ids
+            'project_ids': selected_project_ids,
+            'num_kits': int(num_kits),
+            'num_samples': int(num_samples),
+            'generate_barcodes': generate_barcodes
         }
 
         if prefix:
@@ -537,7 +543,7 @@ def new_kits():
         if barcodes:
             payload['barcodes'] = barcodes
 
-        status, result = APIRequest.post('/api/admin/barcodes', json=payload)
+        status, result = APIRequest.post('/api/admin/add_barcodes', json=payload)
 
         if status != 201:
             return render_template('create_kits.html',
@@ -618,7 +624,7 @@ def new_barcode_kit():
                     'generate_barcode_single': generate_barcode_single
                 }
 
-                status, result = APIRequest.post('/api/admin/barcodes',
+                status, result = APIRequest.post('/api/admin/add_barcodes',
                                                  json=generate_barcode_payload)
                 if status == 500:
                     title = result[5:result.index('\n\n\n')].strip()
@@ -631,7 +637,7 @@ def new_barcode_kit():
                 "barcodes": [result[0]],
                 "kit_ids": kit_ids
             }
-            status, results = APIRequest.post('/api/admin/barcodes',
+            status, results = APIRequest.post('/api/admin/add_barcodes',
                                               json=user_barcode_payload)
             if status == 500:
                 title = results[5:results.index('\n\n\n')].strip()
@@ -648,7 +654,7 @@ def new_barcode_kit():
                 'kit_ids': kit_ids,
                 'generate_barcodes_multiple': generate_barcodes_multiple
             }
-            status, result = APIRequest.post('/api/admin/barcodes',
+            status, result = APIRequest.post('/api/admin/add_barcodes',
                                              json=generate_barcode_payload)
             if status == 500:
                 title = result[5:result.index('\n\n\n')].strip()
@@ -669,7 +675,7 @@ def new_barcode_kit():
             "kit_ids": kit_ids
         }
 
-        status, results = APIRequest.post('/api/admin/barcodes',
+        status, results = APIRequest.post('/api/admin/add_barcodes',
                                           json=csv_payload)
         if status == 500:
             title = results[5:results.index('\n\n\n')].strip()

--- a/microsetta_admin/server.py
+++ b/microsetta_admin/server.py
@@ -543,7 +543,8 @@ def new_kits():
         if barcodes:
             payload['barcodes'] = barcodes
 
-        status, result = APIRequest.post('/api/admin/add_barcodes', json=payload)
+        status, result = APIRequest.post('/api/admin/add_barcodes',
+                                         json=payload)
 
         if status != 201:
             return render_template('create_kits.html',

--- a/microsetta_admin/server.py
+++ b/microsetta_admin/server.py
@@ -518,11 +518,31 @@ def new_kits():
         num_samples = int(request.form['num_samples'])
         prefix = request.form['prefix']
         selected_project_ids = request.form.getlist('project_ids')
+
+        barcodes = []
+
+        barcode_file = request.files.get('upload_csv')
+
+        if barcode_file:
+            barcode_file = barcode_file.read().decode('utf-8')
+            barcodes = [line.split(',')[0].strip('\ufeff\r')
+                        for line in barcode_file.split('\n')
+                        if line.strip()]
+        else:
+            # Process text input
+            for i in range(1, num_samples + 1):
+                barcode = request.form.get(f'barcode_{i}')
+                if barcode:
+                    barcodes.append(barcode)
+
         payload = {'number_of_kits': num_kits,
                    'number_of_samples': num_samples,
                    'project_ids': selected_project_ids}
+
         if prefix:
             payload['kit_id_prefix'] = prefix
+        if barcodes:
+            payload['user_barcodes'] = barcodes
 
         status, result = APIRequest.post(
                 '/api/admin/create/kits',

--- a/microsetta_admin/server.py
+++ b/microsetta_admin/server.py
@@ -554,18 +554,25 @@ def new_kits():
             if barcode_file:
                 # Barcodes provided for this slot
                 barcodes = _read_csv_file(barcode_file)
+                slot_payload = {
+                    'barcodes_provided': True,
+                    'barcodes': barcodes
+                }
             else:
                 # Generate barcodes for this slot
-                barcodes = []
+                slot_payload = {
+                    'barcodes_provided': False,
+                    'barcodes': []
+                }
 
             # Add this slot's barcodes (or empty list) to the container
-            barcodes_container.append(barcodes)
+            barcodes_container.append(slot_payload)
 
         payload = {
             'number_of_kits': num_kits,
             'number_of_samples': num_samples,
             'project_ids': selected_project_ids,
-            'barcodes': barcodes_container
+            'barcodes_container': barcodes_container
         }
 
         if prefix:

--- a/microsetta_admin/templates/add_barcode_to_kit.html
+++ b/microsetta_admin/templates/add_barcode_to_kit.html
@@ -1,0 +1,160 @@
+{% extends "sitebase.html" %}
+{% block head %}
+
+<script src="/static/vendor/js/jquery.validate.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.form/4.3.0/jquery.form.min.js"></script>
+<script>
+    $.validator.addMethod("barcodePattern", function(value, element) {
+        return this.optional(element) || /^X\d{8}$/.test(value);
+    }, "Barcode must start with 'X' followed by 8 digits");
+
+    $(document).ready(function(){
+        // Initialize form validation on the registration form.
+        // It has the name attribute "registration"
+        $("form[name='kit_form']").validate({
+            // Specify validation rules
+            rules: {
+                // The key name on the left side is the name attribute
+                // of an input field. Validation rules are defined
+                // on the right side
+                project_id: "required",
+                num_kits: "required",
+                num_samples: "required",
+                user_barcode: {
+                    barcodePattern: true
+                },
+
+                // Make sure the form is submitted to the destination defined
+                // in the "action" attribute of the form when valid
+                submitHandler: function (form) {
+                    form.submit();
+                }
+            }
+        });
+
+        // Handle form submission
+        $("form[name='kit_form']").submit(function(event) {
+            // Check which button was clicked
+            var submitButton = $("input[type='submit'][clicked=true]").attr('name');
+
+            if (submitButton == 'upload') {
+                // Prevent default form submission
+                event.preventDefault();
+                // Manually submit the form
+                $("#kit_form").ajaxSubmit({
+                    success: function(response) {
+                        // Handle success response
+                        console.log(response);
+                    },
+                    error: function(xhr, status, error) {
+                        // Handle error response
+                        console.error(error);
+                    }
+                });
+            }
+        });
+
+        // Track which button was clicked
+        $("input[type='submit']").click(function() {
+            $("input[type='submit']", $(this).parents("form")).removeAttr("clicked");
+            $(this).attr("clicked", "true");
+        });
+    });
+
+    function setBarcodeFromList() {
+        var barcodeList = document.getElementById("barcodeList");
+        if (barcodeList && barcodeList.children.length > 0) {
+            var barcode = barcodeList.children[0].innerText;
+            document.getElementById("user_barcode").value = barcode;
+        }
+        else {
+            alert("No barcodes to generate");
+        }
+    }
+
+</script>
+
+{% endblock %}
+{% block content %}
+<h3>Add Barcode to Kit(s)</h3>
+<style>
+    select {
+        width: 250px;
+        margin: 10px;
+    }
+</style>
+<div style="height: 335px;">
+    {% if error_message %}
+        <p style="color:red">
+            {{ error_message |e }}
+        </p>
+    {% endif %}
+
+    <form name="kit_form" id="kit_form" method="POST" enctype="multipart/form-data">
+        <table>
+            <tr>
+                <td><label for="project_id">Project ID: </label></td>
+                <td><input type="number" name="project_id" id="project_id"></td>
+            </tr>
+            <tr>
+                <td><label for="num_kits">Number of kit(s): </label></td>
+                <td><input type="number" name="num_kits" id="num_kits" min="1"></td>
+            </tr>
+            <tr>
+                <td><label for="num_samples">Number of sample(s) per kit: </label></td>
+                <td><input type="number" name="num_samples" id="num_samples" min="1"></td>
+            </tr>
+            <tr>
+                <td><label for="kit_id">Kit ID: </label></td>
+                <td><input type="string" name="kit_id" id="kit_id"></td>
+            </tr>
+            <tr>
+                <td><label for="upload_csv">Or upload a CSV file of Kit IDs and/or Barcodes:</label></td>
+                <td><input type="file" name="upload_csv" id="upload_csv"></td>
+            </tr>
+            <tr>
+                <td></td>
+                <td><input type="submit" name="upload" value="Upload CSV"></td>
+            </tr>
+            <tr>
+                
+                <td><label for="user_barcode">Enter barcode: </label></td>
+                <td>
+                    <input 
+                        type="text" 
+                        name="user_barcode" 
+                        id="user_barcode" 
+                        title="Barcode must start with 'X' followed by 8 digits" 
+                        maxlength="9"
+                    >
+                </td>
+            </tr>
+            <tr>
+                <td></td>
+                <td><input type="submit" name="insert_barcode" value="Add barcode(s) to kit"></td>
+            </tr>
+            <tr>
+                <td><label for="generate_barcode">Or generate barcode to add to kit: </label></td>
+                <td><input type="submit" name="insert_barcode" value="Generate barcode(s) to add to kit"></td>
+            </tr>
+        </table>
+        <br>
+        {% if barcodes %}
+            <ul>
+                {% for barcode in barcodes %}
+                    <span>You added {{ barcode }} to Kit ID {{ kit_id }}</span><br>
+                {% endfor %}
+            </ul>
+        {% endif %}
+        {% if search_error %}
+            <p style="color:red">
+            {{search_error |e}}
+            </p>
+        {% endif %}
+        
+        <script>
+           document.agForm.num_kits.focus()
+        </script>
+    </form>
+</div>
+{% endblock %}

--- a/microsetta_admin/templates/add_barcode_to_kit.html
+++ b/microsetta_admin/templates/add_barcode_to_kit.html
@@ -43,7 +43,38 @@
             $('#single_kit_form').hide();
         });
 
-        // Track which button was clicked
+        $("#generate_barcode_single").on("change", function() {
+            if ($(this).is(":checked")) {
+                $("#user_barcode").prop("disabled", true);
+            } else {
+                $("#user_barcode").prop("disabled", false);
+            }
+        });
+
+        $("#user_barcode").on("input", function() {
+            if ($(this).val().length > 0) {
+                $("#generate_barcode_single").prop("disabled", true);
+            } else {
+                $("#generate_barcode_single").prop("disabled", false);
+            }
+        });
+
+        $("#generate_barcodes_multiple").on("change", function() {
+            if ($(this).is(":checked")) {
+                $("#barcodes_file").prop("disabled", true);
+            } else {
+                $("#barcodes_file").prop("disabled", false);
+            }
+        });
+
+        $("#barcodes_file").on("change", function() {
+            if ($(this).val()) {
+                $("#generate_barcodes_multiple").prop("disabled", true);
+            } else {
+                $("#generate_barcodes_multiple").prop("disabled", false);
+            }
+        });
+
         $("input[type='submit']").click(function() {
             $("input[type='submit']", $(this).parents("form")).removeAttr("clicked");
             $(this).attr("clicked", "true");
@@ -109,6 +140,9 @@
     {% endif %}
     <form name="multiple_kits_form" id="multiple_kits_form" method="POST" enctype="multipart/form-data" style="display:none;">
         <table>
+            <br>
+            Upload comma-separated value file(s) (CSV)
+            <br><br>
             <tr>
                 <td><label for="kit_ids">Upload Kit IDs: </label></td>
                 <td><input type="file" name="kit_ids" id="kit_ids" required></td>

--- a/microsetta_admin/templates/add_barcode_to_kit.html
+++ b/microsetta_admin/templates/add_barcode_to_kit.html
@@ -1,57 +1,46 @@
 {% extends "sitebase.html" %}
 {% block head %}
-
 <script src="/static/vendor/js/jquery.validate.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.form/4.3.0/jquery.form.min.js"></script>
 <script>
-    $.validator.addMethod("barcodePattern", function(value, element) {
-        return this.optional(element) || /^X\d{8}$/.test(value);
-    }, "Barcode must start with 'X' followed by 8 digits");
-
     $(document).ready(function(){
         // Initialize form validation on the registration form.
-        // It has the name attribute "registration"
-        $("form[name='kit_form']").validate({
-            // Specify validation rules
+        $("form[name='single_kit_form']").validate({
             rules: {
-                // The key name on the left side is the name attribute
-                // of an input field. Validation rules are defined
-                // on the right side
-                project_id: "required",
-                num_kits: "required",
-                num_samples: "required",
+                kit_id: "required",
                 user_barcode: {
-                    barcodePattern: true
-                },
-
-                // Make sure the form is submitted to the destination defined
-                // in the "action" attribute of the form when valid
-                submitHandler: function (form) {
-                    form.submit();
+                    required: function(element) {
+                        return !$("#generate_barcode_single").is(':checked');
+                    }
                 }
+            },
+            submitHandler: function (form) {
+                form.submit();
             }
         });
 
-        // Handle form submission
-        $("form[name='kit_form']").submit(function(event) {
-            // Check which button was clicked
-            var submitButton = $("input[type='submit'][clicked=true]").attr('name');
-
-            if (submitButton == 'upload') {
-                // Prevent default form submission
-                event.preventDefault();
-                // Manually submit the form
-                $("#kit_form").ajaxSubmit({
-                    success: function(response) {
-                        // Handle success response
-                        console.log(response);
-                    },
-                    error: function(xhr, status, error) {
-                        // Handle error response
-                        console.error(error);
+        $("form[name='multiple_kits_form']").validate({
+            rules: {
+                kit_ids: "required",
+                barcodes_file: {
+                    required: function(element) {
+                        return !$("#generate_barcodes_multiple").is(':checked');
                     }
-                });
+                }
+            },
+            submitHandler: function (form) {
+                form.submit();
             }
+        });
+
+        // Toggle form visibility
+        $('#single_kit_button').click(function() {
+            $('#single_kit_form').show();
+            $('#multiple_kits_form').hide();
+        });
+        $('#multiple_kits_button').click(function() {
+            $('#multiple_kits_form').show();
+            $('#single_kit_form').hide();
         });
 
         // Track which button was clicked
@@ -66,15 +55,13 @@
         if (barcodeList && barcodeList.children.length > 0) {
             var barcode = barcodeList.children[0].innerText;
             document.getElementById("user_barcode").value = barcode;
-        }
-        else {
+        } else {
             alert("No barcodes to generate");
         }
     }
-
 </script>
-
 {% endblock %}
+
 {% block content %}
 <h3>Add Barcode to Kit(s)</h3>
 <style>
@@ -90,71 +77,55 @@
         </p>
     {% endif %}
 
-    <form name="kit_form" id="kit_form" method="POST" enctype="multipart/form-data">
+    <button id="single_kit_button">Add Barcode to Single Kit</button>
+    <button id="multiple_kits_button">Add Barcodes to Multiple Kits</button>
+
+    <form name="single_kit_form" id="single_kit_form" method="POST" style="display:none;">
         <table>
             <tr>
-                <td><label for="project_id">Project ID: </label></td>
-                <td><input type="number" name="project_id" id="project_id"></td>
+                <td><label for="kit_ids">Kit ID: </label></td>
+                <td><input type="text" name="kit_ids" id="kit_ids" required></td>
             </tr>
             <tr>
-                <td><label for="num_kits">Number of kit(s): </label></td>
-                <td><input type="number" name="num_kits" id="num_kits" min="1"></td>
-            </tr>
-            <tr>
-                <td><label for="num_samples">Number of sample(s) per kit: </label></td>
-                <td><input type="number" name="num_samples" id="num_samples" min="1"></td>
-            </tr>
-            <tr>
-                <td><label for="kit_id">Kit ID: </label></td>
-                <td><input type="string" name="kit_id" id="kit_id"></td>
-            </tr>
-            <tr>
-                <td><label for="upload_csv">Or upload a CSV file of Kit IDs and/or Barcodes:</label></td>
-                <td><input type="file" name="upload_csv" id="upload_csv"></td>
-            </tr>
-            <tr>
-                <td></td>
-                <td><input type="submit" name="upload" value="Upload CSV"></td>
-            </tr>
-            <tr>
-                
                 <td><label for="user_barcode">Enter barcode: </label></td>
-                <td>
-                    <input 
-                        type="text" 
-                        name="user_barcode" 
-                        id="user_barcode" 
-                        title="Barcode must start with 'X' followed by 8 digits" 
-                        maxlength="9"
-                    >
-                </td>
+                <td><input type="text" name="user_barcode" id="user_barcode"></td>
+            </tr>
+            <tr>
+                <td><label for="generate_barcode_single">Or generate barcode: </label></td>
+                <td><input type="checkbox" name="generate_barcode_single" id="generate_barcode_single"></td>
             </tr>
             <tr>
                 <td></td>
-                <td><input type="submit" name="insert_barcode" value="Add barcode(s) to kit"></td>
-            </tr>
-            <tr>
-                <td><label for="generate_barcode">Or generate barcode to add to kit: </label></td>
-                <td><input type="submit" name="insert_barcode" value="Generate barcode(s) to add to kit"></td>
+                <td><input type="submit" name="add_single_barcode" value="Add Barcode"></td>
             </tr>
         </table>
-        <br>
-        {% if barcodes %}
-            <ul>
-                {% for barcode in barcodes %}
-                    <span>You added {{ barcode }} to Kit ID {{ kit_id }}</span><br>
-                {% endfor %}
-            </ul>
-        {% endif %}
-        {% if search_error %}
-            <p style="color:red">
-            {{search_error |e}}
-            </p>
-        {% endif %}
-        
-        <script>
-           document.agForm.num_kits.focus()
-        </script>
+    </form>
+    {% if barcodes %}
+        <ul>
+            {% for barcode in barcodes %}
+                <span>You added {{ barcode }} to Kit ID {{ kit_id }}</span><br>
+            {% endfor %}
+        </ul>
+    {% endif %}
+    <form name="multiple_kits_form" id="multiple_kits_form" method="POST" enctype="multipart/form-data" style="display:none;">
+        <table>
+            <tr>
+                <td><label for="kit_ids">Upload Kit IDs: </label></td>
+                <td><input type="file" name="kit_ids" id="kit_ids" required></td>
+            </tr>
+            <tr>
+                <td><label for="barcodes_file">Upload Barcodes: </label></td>
+                <td><input type="file" name="barcodes_file" id="barcodes_file"></td>
+            </tr>
+            <tr>
+                <td><label for="generate_barcodes_multiple">Or generate barcodes: </label></td>
+                <td><input type="checkbox" name="generate_barcodes_multiple" id="generate_barcodes_multiple"></td>
+            </tr>
+            <tr>
+                <td></td>
+                <td><input type="submit" name="add_multiple_barcodes" value="Add Barcodes"></td>
+            </tr>
+        </table>
     </form>
 </div>
 {% endblock %}

--- a/microsetta_admin/templates/add_barcode_to_kit.html
+++ b/microsetta_admin/templates/add_barcode_to_kit.html
@@ -4,7 +4,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.form/4.3.0/jquery.form.min.js"></script>
 <script>
     $(document).ready(function(){
-        // Initialize form validation on the registration form.
+        // Initialize form validation on the form.
         $("form[name='single_kit_form']").validate({
             rules: {
                 kit_id: "required",
@@ -33,14 +33,21 @@
             }
         });
 
+        function clearMessages() {
+            $('#error_message').text("");
+            $('#success_message').empty();
+        }
+
         // Toggle form visibility
         $('#single_kit_button').click(function() {
             $('#single_kit_form').show();
             $('#multiple_kits_form').hide();
+            clearMessages();
         });
         $('#multiple_kits_button').click(function() {
             $('#multiple_kits_form').show();
             $('#single_kit_form').hide();
+            clearMessages();
         });
 
         $("#generate_barcode_single").on("change", function() {
@@ -103,7 +110,7 @@
 </style>
 <div style="height: 335px;">
     {% if error_message %}
-        <p style="color:red">
+        <p id="error_message" style="color:red">
             {{ error_message |e }}
         </p>
     {% endif %}
@@ -132,7 +139,7 @@
         </table>
     </form>
     {% if barcodes %}
-        <ul>
+        <ul id="success_message">
             {% for barcode in barcodes %}
                 <span>You added {{ barcode }} to Kit ID {{ kit_id }}</span><br>
             {% endfor %}

--- a/microsetta_admin/templates/add_barcode_to_kit.html
+++ b/microsetta_admin/templates/add_barcode_to_kit.html
@@ -4,7 +4,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.form/4.3.0/jquery.form.min.js"></script>
 <script>
     $(document).ready(function(){
-        // Initialize form validation on the form.
+        // Initialize form validation
         $("form[name='single_kit_form']").validate({
             rules: {
                 kit_id: "required",
@@ -87,27 +87,11 @@
             $(this).attr("clicked", "true");
         });
     });
-
-    function setBarcodeFromList() {
-        var barcodeList = document.getElementById("barcodeList");
-        if (barcodeList && barcodeList.children.length > 0) {
-            var barcode = barcodeList.children[0].innerText;
-            document.getElementById("user_barcode").value = barcode;
-        } else {
-            alert("No barcodes to generate");
-        }
-    }
 </script>
 {% endblock %}
 
 {% block content %}
-<h3>Add Barcode to Kit(s)</h3>
-<style>
-    select {
-        width: 250px;
-        margin: 10px;
-    }
-</style>
+<h3>Add Barcode(s) to Kit(s)</h3>
 <div style="height: 335px;">
     {% if error_message %}
         <p id="error_message" style="color:red">
@@ -121,20 +105,53 @@
     <form name="single_kit_form" id="single_kit_form" method="POST" style="display:none;">
         <table>
             <tr>
-                <td><label for="kit_ids">Kit ID: </label></td>
-                <td><input type="text" name="kit_ids" id="kit_ids" required></td>
+                <td colspan="2">
+                    <br />
+                </td>
             </tr>
             <tr>
-                <td><label for="user_barcode">Enter barcode: </label></td>
-                <td><input type="text" name="user_barcode" id="user_barcode"></td>
+                <td>
+                    <label for="kit_id" style="margin: auto;">Kit ID: </label>
+                </td>
+                <td>
+                    <input type="text" name="kit_id" id="kit_id" required>
+                </td>
             </tr>
             <tr>
-                <td><label for="generate_barcode_single">Or generate barcode: </label></td>
-                <td><input type="checkbox" name="generate_barcode_single" id="generate_barcode_single"></td>
+                <td colspan="2">
+                    <hr style="width: 100%" />
+                </td>
             </tr>
             <tr>
-                <td></td>
-                <td><input type="submit" name="add_single_barcode" value="Add Barcode"></td>
+                <td>
+                    <label for="user_barcode" style="margin: auto;">Enter Barcode: </label>
+                </td>
+                <td>
+                    <input type="text" name="user_barcode" id="user_barcode">
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2" style="text-align: center; padding-top: 10px; padding-bottom: 10px;">
+                    -- OR --
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label for="generate_barcode_single" style="margin: auto;">Generate Barcode: </label>
+                </td>
+                <td>
+                    <input type="checkbox" name="generate_barcode_single" id="generate_barcode_single">
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <hr style="width: 100%" />
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2" style="text-align: center;">
+                    <input type="submit" name="add_single_barcode" value="Add Barcode">
+                </td>
             </tr>
         </table>
     </form>
@@ -147,24 +164,56 @@
     {% endif %}
     <form name="multiple_kits_form" id="multiple_kits_form" method="POST" enctype="multipart/form-data" style="display:none;">
         <table>
-            <br>
-            Upload comma-separated value file(s) (CSV)
-            <br><br>
             <tr>
-                <td><label for="kit_ids">Upload Kit IDs: </label></td>
-                <td><input type="file" name="kit_ids" id="kit_ids" required></td>
+                <td colspan="2">
+                    <br />
+                    Upload comma-separated value file(s) (CSV)
+                    <br /><br />
+                </td>
             </tr>
             <tr>
-                <td><label for="barcodes_file">Upload Barcodes: </label></td>
-                <td><input type="file" name="barcodes_file" id="barcodes_file"></td>
+                <td>
+                    <label for="kit_ids" style="margin: auto;">Kit IDs: </label>
+                </td>
+                <td>
+                    <input type="file" name="kit_ids" id="kit_ids" required>
+                </td>
             </tr>
             <tr>
-                <td><label for="generate_barcodes_multiple">Or generate barcodes: </label></td>
-                <td><input type="checkbox" name="generate_barcodes_multiple" id="generate_barcodes_multiple"></td>
+                <td colspan="2">
+                    <hr style="width: 100%" />
+                </td>
             </tr>
             <tr>
-                <td></td>
-                <td><input type="submit" name="add_multiple_barcodes" value="Add Barcodes"></td>
+                <td>
+                    <label for="barcodes_file" style="margin: auto;">Barcodes: </label>
+                </td>
+                <td>
+                    <input type="file" name="barcodes_file" id="barcodes_file">
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2" style="text-align: center; padding-top: 10px; padding-bottom: 10px;">
+                    -- OR --
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label for="generate_barcodes_multiple" style="margin: auto;">Generate Barcodes: </label>
+                </td>
+                <td>
+                    <input type="checkbox" name="generate_barcodes_multiple" id="generate_barcodes_multiple">
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <hr style="width: 100%" />
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2" style="text-align: center;">
+                    <input type="submit" name="add_multiple_barcodes" value="Add Barcodes">
+                </td>
             </tr>
         </table>
     </form>

--- a/microsetta_admin/templates/create_kits.html
+++ b/microsetta_admin/templates/create_kits.html
@@ -6,10 +6,18 @@
         $("form[name='kit_form']").validate({
             rules: {
                 number_of_kits: "required",
-                number_of_samples: "required",
+                number_of_samples: {
+                    required: true,
+                    max: 25
+                },
                 project_ids: "required",
                 submitHandler: function (form) {
                     form.submit();
+                }
+            },
+            messages: {
+                number_of_samples: {
+                    max: "You cannot add more than 25 samples per kit."
                 }
             }
         });
@@ -63,7 +71,8 @@
             toggleDisableOptions();
         });
 
-        $("#number_of_samples").val(1).trigger('change'); // Default value to 1 on page load
+        $("#number_of_samples").val(1).trigger('change');
+        $("#number_of_kits").val(1).trigger('change');
     });
 </script>
 <style>

--- a/microsetta_admin/templates/create_kits.html
+++ b/microsetta_admin/templates/create_kits.html
@@ -1,26 +1,13 @@
 {% extends "sitebase.html" %}
 {% block head %}
-
 <script src="/static/vendor/js/jquery.validate.min.js"></script>
 <script>
-    $.validator.addMethod("barcodePattern", function(value, element) {
-        return this.optional(element) || /^X\d{8}$/.test(value);
-    }, "Barcode must start with 'X' followed by 8 digits");
-
     $(document).ready(function(){
-        // Initialize form validation on the registration form.
-        // It has the name attribute "registration"
         $("form[name='kit_form']").validate({
-            // Specify validation rules
             rules: {
-                // The key name on the left side is the name attribute
-                // of an input field. Validation rules are defined
-                // on the right side
                 num_kits: "required",
                 num_samples: "required",
                 project_ids: "required",
-                // Make sure the form is submitted to the destination defined
-                // in the "action" attribute of the form when valid
                 submitHandler: function (form) {
                     form.submit();
                 }
@@ -31,37 +18,37 @@
             var numSamples = $("#num_samples").val();
             var numKits = $("#num_kits").val();
             var totalSamples = numSamples * numKits;
-            var newRows = "";
+            var newSections = "";
             for (var i = 1; i <= totalSamples; i++) {
-                newRows += `<tr>
-                                <td><label for="barcode_${i}">Barcode ${i}: </label></td>
-                                <td><input type="text" name="barcode_${i}" id="barcode_${i}"></td>
-                            </tr>`;
-                            
+                newSections += `<div class="sample-section">
+                                    <p>Sample ${i}</p>
+                                    <label for="upload_csv_${i}">Upload CSV file of Barcodes:</label>
+                                    <input type="file" name="upload_csv_${i}" id="upload_csv_${i}">
+                                    <br>
+                                    <label for="generate_barcodes_${i}">Generate Barcodes</label>
+                                    <input type="checkbox" name="generate_barcodes_${i}" id="generate_barcodes_${i}">
+                                </div>`;
             }
-            if (totalSamples >= 1)
-                $("#barcode_rows").html(newRows);
-
-            for (var j = 1; j <= totalSamples; j++) {
-                $(`#barcode_${j}`).rules("add", {
-                    barcodePattern: true
-                });
-            }
-            validator.resetForm();
-            
+            $("#sample_sections").html(newSections);
         });
+
+        $("#num_samples").val(1).trigger('change'); // Default value to 1 on page load
     });
 </script>
-
-{% endblock %}
-{% block content %}
-<h3>Microsetta Create Kits</h3>
 <style>
     select {
         width: 250px;
         margin: 10px;
     }
+    .sample-section {
+        border: 1px solid #ccc;
+        padding: 10px;
+        margin: 10px 0;
+    }
 </style>
+{% endblock %}
+{% block content %}
+<h3>Microsetta Create Kits</h3>
 <div style="height: 600px;">
     {% if error_message %}
         <p style="color:red">
@@ -77,49 +64,27 @@
             </tr>
             <tr>
                 <td><label for="num_samples">Samples per kit: </label></td>
-                <td><input type="number" name="num_samples" id="num_samples" min="1"></td>
+                <td><input type="number" name="num_samples" id="num_samples" min="1" value="1"></td>
             </tr>
             <tr>
                 <td><label for="prefix">Kit name prefix (optional): </label></td>
-                <td><input type="text" name="prefix" id="prefix" ></td>
+                <td><input type="text" name="prefix" id="prefix"></td>
             </tr>
             <tr>
                 <td><label for="project_ids">Projects: </label></td>
                 <td><select id="project_ids" name="project_ids" multiple class="chosen-select" size=10>
                     {% if projects %}
                     {% for p in projects %}
-
                     <option value='{{p['project_id']}}'>{{p['project_name']}}</option>
-
                     {% endfor %}
                     {% endif %}
                 </select></td>
             </tr>
-            <tr>
-                <td></td>
-                <td><input type="submit" value="Create kits"></td>
-            </tr>
         </table>
-        {% if search_error %}
-            <p style="color:red">
-            {{search_error |e}}
-            </p>
-        {% endif %}
-        <script>
-           document.agForm.num_kits.focus()
-        </script>
-
         <br>
-        <p>Or you can add your barcodes below</p>
+        <div id="sample_sections"></div>
         <br>
-        <div id="barcode_rows"></div>
-        <tr>
-            <td><label for="upload_csv">Or upload a CSV file of Barcodes:</label></td>
-            <td><input type="file" name="upload_csv" id="upload_csv"></td>
-        </tr>
-        <br>
-        <td><input type="submit" name="insert_barcode" value="Add barcode(s) to kit"></td>
+        <input type="submit" value="Create kits">
     </form>
 </div>
-{{blob}}
 {% endblock %}

--- a/microsetta_admin/templates/create_kits.html
+++ b/microsetta_admin/templates/create_kits.html
@@ -5,8 +5,8 @@
     $(document).ready(function(){
         $("form[name='kit_form']").validate({
             rules: {
-                num_kits: "required",
-                num_samples: "required",
+                number_of_kits: "required",
+                number_of_samples: "required",
                 project_ids: "required",
                 submitHandler: function (form) {
                     form.submit();
@@ -14,9 +14,9 @@
             }
         });
 
-        $("#num_samples, #num_kits").on("change", function() {
-            var numSamples = $("#num_samples").val();
-            var numKits = $("#num_kits").val();
+        $("#number_of_samples, #number_of_kits").on("change", function() {
+            var numSamples = $("#number_of_samples").val();
+            var numKits = $("#number_of_kits").val();
             var totalSamples = numSamples * numKits;
             var newSections = "";
             for (var i = 1; i <= totalSamples; i++) {
@@ -32,7 +32,7 @@
             $("#sample_sections").html(newSections);
         });
 
-        $("#num_samples").val(1).trigger('change'); // Default value to 1 on page load
+        $("#number_of_samples").val(1).trigger('change'); // Default value to 1 on page load
     });
 </script>
 <style>
@@ -59,12 +59,12 @@
     <form name="kit_form" id="kit_form" method="POST" enctype="multipart/form-data">
         <table>
             <tr>
-                <td><label for="num_kits">Number of kits: </label></td>
-                <td><input type="number" name="num_kits" id="num_kits" min="1"></td>
+                <td><label for="number_of_kits">Number of kits: </label></td>
+                <td><input type="number" name="number_of_kits" id="number_of_kits" min="1"></td>
             </tr>
             <tr>
-                <td><label for="num_samples">Samples per kit: </label></td>
-                <td><input type="number" name="num_samples" id="num_samples" min="1" value="1"></td>
+                <td><label for="number_of_samples">Samples per kit: </label></td>
+                <td><input type="number" name="number_of_samples" id="number_of_samples" min="1" value="1"></td>
             </tr>
             <tr>
                 <td><label for="prefix">Kit name prefix (optional): </label></td>

--- a/microsetta_admin/templates/create_kits.html
+++ b/microsetta_admin/templates/create_kits.html
@@ -14,22 +14,53 @@
             }
         });
 
+        function adjustContainerHeight() {
+            var numSamples = $("#number_of_samples").val();
+            var containerHeight = 400 + (numSamples * 150);
+            $("#kit_container").css("height", containerHeight + "px");
+        }
+
+        function toggleDisableOptions() {
+            $(".sample-section").each(function() {
+                var $uploadCsvInput = $(this).find("input[type='file']");
+                var $generateBarcodesCheckbox = $(this).find("input[type='checkbox']");
+                
+                $uploadCsvInput.on("change", function() {
+                    if ($(this).val()) {
+                        $generateBarcodesCheckbox.prop("disabled", true);
+                    } else {
+                        $generateBarcodesCheckbox.prop("disabled", false);
+                    }
+                });
+
+                $generateBarcodesCheckbox.on("change", function() {
+                    if ($(this).is(":checked")) {
+                        $uploadCsvInput.prop("disabled", true);
+                    } else {
+                        $uploadCsvInput.prop("disabled", false);
+                    }
+                });
+            });
+        }
+
         $("#number_of_samples, #number_of_kits").on("change", function() {
             var numSamples = $("#number_of_samples").val();
             var numKits = $("#number_of_kits").val();
-            var totalSamples = numSamples * numKits;
             var newSections = "";
-            for (var i = 1; i <= totalSamples; i++) {
+            for (var j = 1; j <= numSamples; j++) {
                 newSections += `<div class="sample-section">
-                                    <p>Sample ${i}</p>
-                                    <label for="upload_csv_${i}">Upload CSV file of Barcodes:</label>
-                                    <input type="file" name="upload_csv_${i}" id="upload_csv_${i}">
+                                    <h4>Sample ${j}</h4>
+                                    <p>Upload CSV with ${numKits} row(s) of barcode(s) for this sample:</p>
+                                    <label for="upload_csv_${j}">Upload CSV file:</label>
+                                    <input type="file" name="upload_csv_${j}" id="upload_csv_${j}">
                                     <br>
-                                    <label for="generate_barcodes_${i}">Generate Barcodes</label>
-                                    <input type="checkbox" name="generate_barcodes_${i}" id="generate_barcodes_${i}">
+                                    <label for="generate_barcodes_sample_${j}">Generate Barcodes</label>
+                                    <input type="checkbox" name="generate_barcodes_sample_${j}" id="generate_barcodes_sample_${j}">
                                 </div>`;
             }
             $("#sample_sections").html(newSections);
+            adjustContainerHeight();
+            toggleDisableOptions();
         });
 
         $("#number_of_samples").val(1).trigger('change'); // Default value to 1 on page load
@@ -40,6 +71,11 @@
         width: 250px;
         margin: 10px;
     }
+    .kit-section {
+        border: 1px solid #ccc;
+        padding: 10px;
+        margin: 20px 0;
+    }
     .sample-section {
         border: 1px solid #ccc;
         padding: 10px;
@@ -49,7 +85,7 @@
 {% endblock %}
 {% block content %}
 <h3>Microsetta Create Kits</h3>
-<div style="height: 600px;">
+<div id="kit_container" style="height: 600px;">
     {% if error_message %}
         <p style="color:red">
             {{ error_message |e }}

--- a/microsetta_admin/templates/create_kits.html
+++ b/microsetta_admin/templates/create_kits.html
@@ -6,25 +6,17 @@
         $("form[name='kit_form']").validate({
             rules: {
                 number_of_kits: "required",
-                number_of_samples: {
-                    required: true,
-                    max: 25
-                },
+                number_of_samples: "required",
                 project_ids: "required",
                 submitHandler: function (form) {
                     form.submit();
-                }
-            },
-            messages: {
-                number_of_samples: {
-                    max: "You cannot add more than 25 samples per kit."
                 }
             }
         });
 
         function adjustContainerHeight() {
             var numSamples = $("#number_of_samples").val();
-            var containerHeight = 400 + (numSamples * 150);
+            var containerHeight = 400 + (numSamples * 190);
             $("#kit_container").css("height", containerHeight + "px");
         }
 
@@ -59,10 +51,12 @@
                 newSections += `<div class="sample-section">
                                     <h4>Sample ${j}</h4>
                                     <p>Upload CSV with ${numKits} row(s) of barcode(s) for this sample:</p>
-                                    <label for="upload_csv_${j}">Upload CSV file:</label>
+                                    <label for="upload_csv_${j}">Barcodes:</label>
                                     <input type="file" name="upload_csv_${j}" id="upload_csv_${j}">
-                                    <br>
-                                    <label for="generate_barcodes_sample_${j}">Generate Barcodes</label>
+                                    <br />
+                                    <center>-- OR --</center>
+                                    <br />
+                                    <label for="generate_barcodes_sample_${j}">Generate Barcodes:</label>
                                     <input type="checkbox" name="generate_barcodes_sample_${j}" id="generate_barcodes_sample_${j}">
                                 </div>`;
             }

--- a/microsetta_admin/templates/create_kits.html
+++ b/microsetta_admin/templates/create_kits.html
@@ -3,6 +3,10 @@
 
 <script src="/static/vendor/js/jquery.validate.min.js"></script>
 <script>
+    $.validator.addMethod("barcodePattern", function(value, element) {
+        return this.optional(element) || /^X\d{8}$/.test(value);
+    }, "Barcode must start with 'X' followed by 8 digits");
+
     $(document).ready(function(){
         // Initialize form validation on the registration form.
         // It has the name attribute "registration"
@@ -22,6 +26,30 @@
                 }
             }
         });
+
+        $("#num_samples, #num_kits").on("change", function() {
+            var numSamples = $("#num_samples").val();
+            var numKits = $("#num_kits").val();
+            var totalSamples = numSamples * numKits;
+            var newRows = "";
+            for (var i = 1; i <= totalSamples; i++) {
+                newRows += `<tr>
+                                <td><label for="barcode_${i}">Barcode ${i}: </label></td>
+                                <td><input type="text" name="barcode_${i}" id="barcode_${i}"></td>
+                            </tr>`;
+                            
+            }
+            if (totalSamples >= 1)
+                $("#barcode_rows").html(newRows);
+
+            for (var j = 1; j <= totalSamples; j++) {
+                $(`#barcode_${j}`).rules("add", {
+                    barcodePattern: true
+                });
+            }
+            validator.resetForm();
+            
+        });
     });
 </script>
 
@@ -34,14 +62,14 @@
         margin: 10px;
     }
 </style>
-<div style="height: 400px;">
+<div style="height: 600px;">
     {% if error_message %}
         <p style="color:red">
             {{ error_message |e }}
         </p>
     {% endif %}
 
-    <form name="kit_form" id="kit_form" method="POST">
+    <form name="kit_form" id="kit_form" method="POST" enctype="multipart/form-data">
         <table>
             <tr>
                 <td><label for="num_kits">Number of kits: </label></td>
@@ -80,6 +108,17 @@
         <script>
            document.agForm.num_kits.focus()
         </script>
+
+        <br>
+        <p>Or you can add your barcodes below</p>
+        <br>
+        <div id="barcode_rows"></div>
+        <tr>
+            <td><label for="upload_csv">Or upload a CSV file of Barcodes:</label></td>
+            <td><input type="file" name="upload_csv" id="upload_csv"></td>
+        </tr>
+        <br>
+        <td><input type="submit" name="insert_barcode" value="Add barcode(s) to kit"></td>
     </form>
 </div>
 {{blob}}

--- a/microsetta_admin/templates/sitebase.html
+++ b/microsetta_admin/templates/sitebase.html
@@ -47,11 +47,17 @@
             <li><a href="#" onclick="showWait('/manage_projects?is_active=true')">Manage Projects</a></li>
             <li><a href="/email_stats">Account Summaries</a></li>
             <li><a href="/create_kits">Create Kit</a></li>
+            <li><a href="/add_barcode_to_kit">Add Barcode to Kit</a></li>
             <li><a href="/scan">Scan Barcode</a></li>
             <li><a href="/metadata_pulldown">Retrieve Metadata</a></li>
             <li><a href="/per_sample_summary">Sample Summaries</a></li>
             <li><a href="/submit_daklapack_order">Submit Daklapack Order</a></li>
-            <li><a href="{{authrocket_url}}/logout?redirect_uri={{endpoint}}/logout">Log Out <br> ({{email |e}})</a></li>
+            <li>
+                <a href="{{authrocket_url}}/logout?redirect_uri={{endpoint}}/logout"
+                   style="max-width: 200px; display: inline-block; word-wrap: break-word;">
+                    Log Out ({{email |e}})
+                </a>
+            </li>
             {% else %}
             <li><a href="{{authrocket_url}}/login?redirect_uri={{endpoint}}/authrocket_callback">Log In</a></li>
             {% endif %}

--- a/microsetta_admin/templates/sitebase.html
+++ b/microsetta_admin/templates/sitebase.html
@@ -46,8 +46,8 @@
             <li><a href="/search">Search</a></li>
             <li><a href="#" onclick="showWait('/manage_projects?is_active=true')">Manage Projects</a></li>
             <li><a href="/email_stats">Account Summaries</a></li>
-            <li><a href="/create_kits">Create Kit</a></li>
-            <li><a href="/add_barcode_to_kit">Add Barcode to Kit</a></li>
+            <li><a href="/create_kits">Create Kit(s)</a></li>
+            <li><a href="/add_barcode_to_kit">Add Barcode(s) to Kit(s)</a></li>
             <li><a href="/scan">Scan Barcode</a></li>
             <li><a href="/metadata_pulldown">Retrieve Metadata</a></li>
             <li><a href="/per_sample_summary">Sample Summaries</a></li>

--- a/microsetta_admin/tests/test_routes.py
+++ b/microsetta_admin/tests/test_routes.py
@@ -360,14 +360,13 @@ class RouteTests(TestBase):
         self.mock_post.return_value = DummyResponse(201, {})
 
         response = self.app.post('/add_barcode_to_kit',
-                                 data={'project_id': '1',
-                                       'num_kits': '1',
-                                       'kit_id': 'FBGBs',
-                                       'num_samples': '1',
-                                       'user_barcode': 'X11204416'},
+                                 data={'kit_ids': 'FBGBs',
+                                       'user_barcode': 'X64406585',
+                                       'generate_barcode_single': 'off',
+                                       'add_single_barcode': 'Add Barcode'},
                                  follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'You added X11204416 to Kit ID FBGBs', response.data)
+        self.assertIn(b'You added X64406585 to Kit ID FBGBs', response.data)
 
     def test_create_insert_barcode_from_csv(self):
         self.mock_post.return_value = DummyResponse(201, {})
@@ -378,10 +377,7 @@ class RouteTests(TestBase):
 
         with open(temp_file.name, 'rb') as f:
             response = self.app.post('/add_barcode_to_kit',
-                                     data={'project_id': '1',
-                                           'num_kits': '1',
-                                           'kit_id': 'FBGBs',
-                                           'num_samples': '3',
+                                     data={'kit_id': 'FBGBs',
                                            'user_barcode': 'X11204416',
                                            'upload_csv': (f, 'test.csv')},
                                      follow_redirects=True)

--- a/microsetta_admin/tests/test_routes.py
+++ b/microsetta_admin/tests/test_routes.py
@@ -1,7 +1,5 @@
-import csv
 import json
 from copy import deepcopy
-import tempfile
 
 from microsetta_admin.tests.base import TestBase
 

--- a/microsetta_admin/tests/test_routes.py
+++ b/microsetta_admin/tests/test_routes.py
@@ -401,53 +401,6 @@ class RouteTests(TestBase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'Unable to create project.', response.data)
 
-    def test_insert_barcode_success(self):
-        self.mock_post.return_value = DummyResponse(201, {})
-
-        response = self.app.post('/add_barcode_to_kit',
-                                 data={'kit_id': 'test',
-                                       'user_barcode': 'X64444485'},
-                                 follow_redirects=True)
-        self.assertEqual(response.status_code, 201)
-
-    def test_insert_barcode_from_csv(self):
-        self.mock_post.return_value = DummyResponse(201, {})
-
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
-            csv_writer = csv.writer(temp_file)
-            csv_writer.writerow(['X11204416'])
-
-        with open(temp_file.name, 'rb') as f:
-            response = self.app.post('/add_barcode_to_kit',
-                                     data={'kit_ids': 'test',
-                                           'barcodes_file': (f, 'test.csv')},
-                                     follow_redirects=True)
-        self.assertEqual(response.status_code, 400)
-
-    def test_insert_barcode_fail_kit_id(self):
-        self.mock_post.return_value = DummyResponse(404, {})
-
-        response = self.app.post('/add_barcode_to_kit',
-                                 data={'kit_ids': 'alpha9',
-                                       'generate_barcode_single': 'on'},
-                                 follow_redirects=True)
-        self.assertEqual(response.status_code, 404)
-
-    def test_insert_barcode_fail_csv_mismatch(self):
-        self.mock_post.return_value = DummyResponse(201, {})
-
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
-            csv_writer = csv.writer(temp_file)
-            csv_writer.writerow(['X11204415'])
-            csv_writer.writerow(['X11204416'])
-
-        with open(temp_file.name, 'rb') as f:
-            response = self.app.post('/add_barcode_to_kit',
-                                     data={'kit_ids': 'test',
-                                           'barcodes_file': (f, 'test.csv')},
-                                     follow_redirects=True)
-        self.assertEqual(response.status_code, 400)
-
     def test_update_project_success(self):
         self.mock_put.return_value = DummyResponse(204, {})
         self.mock_get.return_value = DummyResponse(200, self.PROJ_LIST)

--- a/microsetta_admin/tests/test_routes.py
+++ b/microsetta_admin/tests/test_routes.py
@@ -356,19 +356,16 @@ class RouteTests(TestBase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'Unable to create project.', response.data)
 
-    def test_create_insert_barcode_success(self):
+    def test_insert_barcode_success(self):
         self.mock_post.return_value = DummyResponse(201, {})
 
         response = self.app.post('/add_barcode_to_kit',
-                                 data={'kit_ids': 'FBGBs',
-                                       'user_barcode': 'X64406585',
-                                       'generate_barcode_single': 'off',
-                                       'add_single_barcode': 'Add Barcode'},
+                                 data={'kit_id': 'test',
+                                       'user_barcode': 'X64444485'},
                                  follow_redirects=True)
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'You added X64406585 to Kit ID FBGBs', response.data)
 
-    def test_create_insert_barcode_from_csv(self):
+    def test_insert_barcode_from_csv(self):
         self.mock_post.return_value = DummyResponse(201, {})
 
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:

--- a/microsetta_admin/tests/test_routes.py
+++ b/microsetta_admin/tests/test_routes.py
@@ -363,22 +363,45 @@ class RouteTests(TestBase):
                                  data={'kit_id': 'test',
                                        'user_barcode': 'X64444485'},
                                  follow_redirects=True)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 201)
 
     def test_insert_barcode_from_csv(self):
         self.mock_post.return_value = DummyResponse(201, {})
 
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
             csv_writer = csv.writer(temp_file)
-            csv_writer.writerow(['FBGBs'])
+            csv_writer.writerow(['X11204416'])
 
         with open(temp_file.name, 'rb') as f:
             response = self.app.post('/add_barcode_to_kit',
-                                     data={'kit_id': 'FBGBs',
-                                           'user_barcode': 'X11204416',
-                                           'upload_csv': (f, 'test.csv')},
+                                     data={'kit_ids': 'test',
+                                           'barcodes_file': (f, 'test.csv')},
                                      follow_redirects=True)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 400)
+
+    def test_insert_barcode_fail_kit_id(self):
+        self.mock_post.return_value = DummyResponse(404, {})
+
+        response = self.app.post('/add_barcode_to_kit',
+                                 data={'kit_ids': 'alpha9',
+                                       'generate_barcode_single': 'on'},
+                                 follow_redirects=True)
+        self.assertEqual(response.status_code, 404)
+
+    def test_insert_barcode_fail_csv_mismatch(self):
+        self.mock_post.return_value = DummyResponse(201, {})
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
+            csv_writer = csv.writer(temp_file)
+            csv_writer.writerow(['X11204415'])
+            csv_writer.writerow(['X11204416'])
+
+        with open(temp_file.name, 'rb') as f:
+            response = self.app.post('/add_barcode_to_kit',
+                                     data={'kit_ids': 'test',
+                                           'barcodes_file': (f, 'test.csv')},
+                                     follow_redirects=True)
+        self.assertEqual(response.status_code, 400)
 
     def test_update_project_success(self):
         self.mock_put.return_value = DummyResponse(204, {})


### PR DESCRIPTION
This PR addresses two related needs:
1) It allows an admin to add barcodes to existing kits, either by providing barcodes or allowing the system to generate novel barcodes.
2) It enhances the kit creation process by allowing the admin to create kits with a mix of admin-provided barcodes (e.g. matrix tubes with pre-determined barcodes) and system-generated barcodes.

The corresponding microsetta-private-api PR is https://github.com/biocore/microsetta-private-api/pull/590/