### PR TITLE
Add Box ID to Sample Summary

### DIFF
--- a/microsetta_admin/server.py
+++ b/microsetta_admin/server.py
@@ -386,7 +386,7 @@ def per_sample_summary():
                          'no-associated-source', 'no-collection-info',
                          'no-registered-account', 'received-unknown-validity',
                          'ffq-taken', 'ffq-complete', 'vioscreen_username',
-                         'kit-id', 'outbound-tracking',
+                         'kit-id', 'box-id', 'outbound-tracking',
                          'inbound-tracking', 'daklapack-order-id'
                          ]
                 order.extend(sorted(set(resource.columns) - set(order)))
@@ -454,7 +454,7 @@ def per_sample_summary():
                          'no-associated-source', 'no-collection-info',
                          'no-registered-account', 'received-unknown-validity',
                          'ffq-taken', 'ffq-complete', 'vioscreen_username',
-                         'kit-id', 'outbound-tracking',
+                         'kit-id', 'box-id', 'outbound-tracking',
                          'inbound-tracking', 'daklapack-order-id'
                          ]
                 order.extend(sorted(set(resource.columns) - set(order)))

--- a/microsetta_admin/templates/per_sample_summary.html
+++ b/microsetta_admin/templates/per_sample_summary.html
@@ -61,6 +61,7 @@
                     <select id="search_field" name="search_field">
                         <option value="sample_barcodes">Barcode</option>
                         <option value="kit_ids">Kit ID</option>
+                        <option value="box_ids">Box ID</option>
                         <option value="emails">Email</option>
                         <option value="outbound_tracking_numbers">Outbound Tracking Number</option>
                         <option value="inbound_tracking_numbers">Inbound Tracking Number</option>


### PR DESCRIPTION
This PR adds the Box ID to the Sample Summary report in microsetta-admin, both as a search parameter and an output field.

Corresponding microsetta-private-api PR: https://github.com/biocore/microsetta-private-api/pull/606